### PR TITLE
feat: add singletons support for sanity toolkit

### DIFF
--- a/packages/sanity-toolkit/studio/singletons/index.ts
+++ b/packages/sanity-toolkit/studio/singletons/index.ts
@@ -1,0 +1,3 @@
+export * from './plugin';
+export * from './schema';
+export * from './structure';

--- a/packages/sanity-toolkit/studio/singletons/plugin.ts
+++ b/packages/sanity-toolkit/studio/singletons/plugin.ts
@@ -1,0 +1,38 @@
+import type { DocumentActionComponent, PluginOptions } from 'sanity';
+
+/**
+ * This plugin contains the logic for setting up the singletons.
+ */
+
+export function setupSingletons(LOCKED_DOCUMENT_TYPES: Array<string>): PluginOptions {
+  return {
+    name: 'singletonPlugin',
+    document: {
+      // Hide Singletons (such as Homepage) from new document options, so they can't be created in global new document window
+      // https://user-images.githubusercontent.com/81981/195728798-e0c6cf7e-d442-4e58-af3a-8cd99d7fcc28.png
+      newDocumentOptions: (prev, { creationContext }) => {
+        if (creationContext.type === 'global') {
+          return prev.filter(
+            (templateItem) => !LOCKED_DOCUMENT_TYPES.includes(templateItem.templateId),
+          );
+        }
+
+        return prev;
+      },
+
+      // Removes the "duplicate", "unpublish" and "delete" actions on Singletons (such as Homepage or Site Config)
+      actions: (actions, { schemaType }) => {
+        const isSingleton = LOCKED_DOCUMENT_TYPES.includes(schemaType);
+
+        if (isSingleton) {
+          actions = actions.filter(
+            ({ action }: DocumentActionComponent) =>
+              action !== 'duplicate' && action !== 'unpublish' && action !== 'delete',
+          );
+        }
+
+        return actions;
+      },
+    },
+  };
+}

--- a/packages/sanity-toolkit/studio/singletons/schema.ts
+++ b/packages/sanity-toolkit/studio/singletons/schema.ts
@@ -1,0 +1,30 @@
+import { defineField } from 'sanity';
+import { isDeveloperOrAdmin } from '../utilities/roles';
+
+/**
+ * When searching for documents, Sanity will search on the document content.
+ * However, Singleton's often do not contain content that describes what you're looking for.
+ * For example, the SEO + Social Singleton should appear in searches for SEO, but it doesn't.
+ *
+ * Therefore, we add a hidden Title field to Singletons to allow them to better appear in global search.
+ *
+ * You may still customise the Preview for your Singleton to choose how it appears in the search box.
+ *
+ * If a Singleton document was created before this field was added, it will have no value. If it has no value,
+ * it will not be hidden, so that a value can be added.
+ *
+ * Import this function into your app, change any of the values as needed, then use your function
+ * across your application.
+ */
+export function defineSingletonTitle(title: string, name = 'title') {
+  return defineField({
+    title: '[Dev] Singleton Title',
+    description:
+      'Title for this Singleton which is indexed in global search. Shown only to Admins and Developers',
+    name,
+    type: 'string',
+    initialValue: title,
+    readOnly: ({ currentUser }) => !isDeveloperOrAdmin(currentUser),
+    hidden: ({ currentUser }) => !isDeveloperOrAdmin(currentUser),
+  });
+}

--- a/packages/sanity-toolkit/studio/singletons/structure.ts
+++ b/packages/sanity-toolkit/studio/singletons/structure.ts
@@ -1,0 +1,19 @@
+export const SINGLETON_DOC_PREFIX = `singleton`;
+
+export const PRIVATE = true;
+export const NOT_PRIVATE = false;
+
+/**
+ * Used to get the singleton document ID for a particular schema type.
+ * This ensures a consistent document ID for a particular singleton.
+ * It can also ensure a singleton is public, even if it has a dot in its schema type name.
+ */
+export function singletonDocId(schemaType: string, isPrivate = false) {
+  const singletonDocId = `${SINGLETON_DOC_PREFIX}-${schemaType}`.replaceAll(' ', '-'); // IDs with spaces in are not valid, so remove them.
+
+  if (!isPrivate) {
+    return singletonDocId.replaceAll('.', '_'); // Document id's with a dot in are made private by default, so remove that for this utility.
+  }
+
+  return singletonDocId;
+}

--- a/packages/sanity-toolkit/studio/structure/singletonListItem.ts
+++ b/packages/sanity-toolkit/studio/structure/singletonListItem.ts
@@ -1,0 +1,47 @@
+import type {
+  ListItemBuilder,
+  StructureBuilder,
+  StructureResolverContext,
+} from 'sanity/structure';
+import type { SingletonListItem } from '../types';
+import { singletonDocId } from '../singletons/structure';
+
+/**
+ * Helper function to create a ListItem in your Structure for a Singleton.
+ *
+ * Import this function into your app, and pass in the `defaultViews`, then export it and use
+ * it in your application structure.
+ *
+ * e.g.
+ *   import { singletonListItem as singletonListItemPkg } from '@pkg/sanity-toolkit/structure/singletonListItem';
+ *
+ *   export function singletonListItem(S: StructureBuilder, context: StructureContext, options: SingletonListItem) {
+ *     return singletonListItemPkg(S, context, { ...options, defaultViews: defaultViews(S, { documentId, schemaType, ...context }) });
+ *   }
+ */
+export function singletonListItem(
+  S: StructureBuilder,
+  context: StructureResolverContext,
+  { title, viewTitle, schemaType, icon, isPrivate, defaultViews }: SingletonListItem,
+): ListItemBuilder {
+  const documentId = singletonDocId(schemaType, isPrivate);
+
+  const { schema } = context;
+  const documentSchema = schema.get(schemaType);
+
+  const itemTitle = title ?? documentSchema?.title ?? 'Unnamed';
+
+  return S.listItem()
+    .id(documentId)
+    .title(itemTitle)
+    .icon(icon ?? documentSchema?.icon)
+    .schemaType(schemaType)
+    .child(
+      S.editor()
+        .id(documentId)
+        .title(viewTitle ?? itemTitle)
+        .schemaType(schemaType)
+        .documentId(documentId)
+        .views(defaultViews ?? []),
+    );
+}

--- a/packages/sanity-toolkit/studio/types/index.ts
+++ b/packages/sanity-toolkit/studio/types/index.ts
@@ -1,0 +1,11 @@
+import type { ComponentType, ReactNode } from 'react';
+import type { View, ViewBuilder } from 'sanity/structure';
+
+export interface SingletonListItem {
+  schemaType: string;
+  title?: string;
+  viewTitle?: string;
+  icon?: ComponentType | ReactNode;
+  isPrivate?: boolean;
+  defaultViews?: Array<View | ViewBuilder>;
+}


### PR DESCRIPTION
# Overview

This PR adds common utilities for Singletons to the toolkit.

**Singleton Plugin**
- [x] Hide Singletons from the "new document options", so they can't be created in global new document window (https://user-images.githubusercontent.com/81981/195728798-e0c6cf7e-d442-4e58-af3a-8cd99d7fcc28.png)
- [x] Removes the "duplicate", "unpublish" and "delete" actions on Singletons

**Utilities**
- [x] Utility for adding a title field to Singletons that's only visible to devs and admins. Titles should be added so singletons correctly appear in backlinks
- [x] Utility for taking a singleton schema name and returning a consistent document ID to use for that singleton. Optionally ensures singleton isn't private even when there is a dot in the singleton schema name
- [x] Helper function to create a ListItem in your Structure for a Singleton