### PR TITLE
feat: add recycling bin to sanity toolkit

### DIFF
--- a/apps/sanity/schema/types/singletons.ts
+++ b/apps/sanity/schema/types/singletons.ts
@@ -1,3 +1,7 @@
 import { SchemaTypeDefinition } from 'sanity';
+import { recyclingBinDocument } from '@pkg/sanity-toolkit/recycling-bin/schema';
+import { SINGLETON } from '@pkg/common/constants/schemaTypes';
 
-export const singletons: SchemaTypeDefinition[] = [];
+export const singletons: SchemaTypeDefinition[] = [
+  recyclingBinDocument(SINGLETON.RECYCLING_BIN),
+];

--- a/apps/sanity/structure/index.ts
+++ b/apps/sanity/structure/index.ts
@@ -184,13 +184,12 @@ export const structure: StructureResolver = (S, ctx) => {
       //       ]),
       //   ),
       S.divider(),
-      placeholder(S, 'Recycling Bin', CogIcon),
-      // singletonListItem(S, context, {
-      //   title: 'Recycling Bin',
-      //   viewTitle: 'Recycling Bin',
-      //   schemaType: SINGLETON.RECYCLING_BIN,
-      //   isPrivate: true,
-      // }),
+      singletonListItem(S, context, {
+        title: 'Recycling Bin',
+        viewTitle: 'Recycling Bin',
+        schemaType: SINGLETON.RECYCLING_BIN,
+        isPrivate: true,
+      }),
       S.divider(),
 
       // Add a Skeleton Key for developers to see all document types easily

--- a/packages/sanity-toolkit/package.json
+++ b/packages/sanity-toolkit/package.json
@@ -29,6 +29,7 @@
     "@sanity/types": "^3.61.0",
     "@sanity/ui": "^2.8.9",
     "@types/react": "^18",
+    "groq": "^3.62.2",
     "react": "^18",
     "react-icons": "^5.3.0",
     "sanity": "^3.60.0",

--- a/packages/sanity-toolkit/recycling-bin/DeletedDocIdInputComponent.tsx
+++ b/packages/sanity-toolkit/recycling-bin/DeletedDocIdInputComponent.tsx
@@ -1,0 +1,13 @@
+import { Card, Flex, Text } from '@sanity/ui';
+import { type ComponentType } from 'react';
+import { type StringInputProps } from 'sanity';
+
+export const DeletedDocIdInputComponent: ComponentType<StringInputProps> = (props) => {
+  return (
+    <Flex justify={'space-between'} align={'center'} gap={2} paddingLeft={2} paddingY={2}>
+      <Card>
+        <Text>{props.value}</Text>
+      </Card>
+    </Flex>
+  );
+};

--- a/packages/sanity-toolkit/recycling-bin/DeletionLogInputComponent.tsx
+++ b/packages/sanity-toolkit/recycling-bin/DeletionLogInputComponent.tsx
@@ -5,8 +5,6 @@ import { type ComponentType, useState } from 'react';
 import { type ArrayOfObjectsInputProps, useClient, useFormValue } from 'sanity';
 import type { LogItem } from './types';
 
-/* eslint-disable */
-
 /** ### Array Input Component with Button to clean up the log
  *
  * removes restored documents from the logs array

--- a/packages/sanity-toolkit/recycling-bin/DeletionLogInputComponent.tsx
+++ b/packages/sanity-toolkit/recycling-bin/DeletionLogInputComponent.tsx
@@ -1,0 +1,78 @@
+import { RemoveCircleIcon } from '@sanity/icons';
+import { Button, Stack } from '@sanity/ui';
+import groq from 'groq';
+import { type ComponentType, useState } from 'react';
+import { type ArrayOfObjectsInputProps, useClient, useFormValue } from 'sanity';
+import type { LogItem } from './types';
+
+/* eslint-disable */
+
+/** ### Array Input Component with Button to clean up the log
+ *
+ * removes restored documents from the logs array
+ */
+export const DeletionLogInputComponent: ComponentType<ArrayOfObjectsInputProps> = (props) => {
+  // * Get the client
+  const client = useClient({ apiVersion: '2024-04-23' }).withConfig({
+    perspective: 'previewDrafts',
+  });
+
+  // * Get Ids and filter unique values
+  /** Ids from `props.value` which are also filtered to only return unique IDs */
+  const ids = props.value
+    // @ts-ignore Need to fix this, but was taken from a Sanity guide
+    ?.map((item: LogItem) => item.docId)
+    .filter((value, index, self) => self.indexOf(value) === index);
+
+  // * Get the document ID
+  /** ID of current `deletedDocIdsDocument` */
+  const documentID = useFormValue(['_id']) as string;
+
+  // * Set the logs state which will be set by a query
+  // that fetches all document ids that are in the logs and check if they exist
+  const [logs, setLogs] = useState<{ docId: string }[]>([]);
+  const query = groq`*[_id in $docIds]{
+              'docId': _id,
+            }`;
+  const params = { docIds: ids };
+
+  // * Fetch the data to check if the documents exist
+  const fetchData = async () => {
+    await client
+      .fetch(query, params)
+      .then((res) => {
+        setLogs(res);
+      })
+      .catch((err) => {
+        console.error(err.message);
+      });
+  };
+
+  // * Create an array of items to unset for documents that were restored
+  const itemsToUnset = logs.map((item) => `deletedDocLogs[docId == "${item.docId}"]`);
+  // * Function to handle the cleanup of restored documents
+  /** simple function to check document IDs for existence and unset existing items if there is a `documentID` via the client */
+  const handleCleanUp = () => {
+    // * Run the function only when there is a value and a documentID
+    props.value &&
+      documentID &&
+      fetchData().then(() =>
+        client.patch(documentID).unset(itemsToUnset).commit().catch(console.error),
+      );
+  };
+
+  return (
+    <Stack space={4}>
+      <Button
+        text="Remove restored Document from Logs"
+        icon={RemoveCircleIcon}
+        onClick={() => {
+          handleCleanUp();
+        }}
+        mode="ghost"
+      />
+      {/* Remove the Add Item button below the Array input */}
+      {props.renderDefault({ ...props, arrayFunctions: () => null })}
+    </Stack>
+  );
+};

--- a/packages/sanity-toolkit/recycling-bin/DeletionLogItemComponent.tsx
+++ b/packages/sanity-toolkit/recycling-bin/DeletionLogItemComponent.tsx
@@ -1,0 +1,66 @@
+import { RestoreIcon } from '@sanity/icons';
+import { Card, Flex, Stack, Text } from '@sanity/ui';
+import type { ComponentType } from 'react';
+import { IntentButton, type ObjectItemProps } from 'sanity';
+import type { LogItem } from './types';
+
+export const DeletionLogItemComponent: ComponentType<ObjectItemProps<LogItem>> = (props) => {
+  const value = props.value;
+
+  const date = new Date(value.deletedAt);
+  const months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  const formattedDate = `${date.getDate()}.${months[date.getMonth()]} ${date.getFullYear()}`;
+
+  return (
+    <Card borderTop={props.index > 0}>
+      {/* Flex container for "custom" item preview and Intent Button */}
+      <Flex justify={'space-between'} align={'center'} gap={2} paddingX={4} paddingY={4}>
+        {/* Custom item preview with the document title, type and date */}
+        <Stack space={3}>
+          <Text weight="semibold">{value.documentTitle}</Text>
+          <Text muted size={1}>
+            Type: {value.type}
+          </Text>
+
+          <Text muted size={1}>
+            Deleted: {formattedDate}
+          </Text>
+          <Text muted size={0}>
+            ID: {value.docId}, Revision: {value._key}
+          </Text>
+        </Stack>
+        {/* Intent Button */}
+        {value.docId && (
+          <IntentButton
+            icon={RestoreIcon}
+            tone={'positive'}
+            mode="ghost"
+            intent="edit"
+            params={{
+              type: value.type,
+              id: value.docId,
+            }}
+            text="Open to restore"
+            tooltipProps={{
+              placement: 'top',
+              content: 'You can restore this document after opening it',
+            }}
+          />
+        )}
+      </Flex>
+    </Card>
+  );
+};

--- a/packages/sanity-toolkit/recycling-bin/newBinSingleton.json
+++ b/packages/sanity-toolkit/recycling-bin/newBinSingleton.json
@@ -1,0 +1,5 @@
+{
+  "_id": "deletedDocs.bin",
+  "_type": "deletedDocs.bin",
+  "title": "Bin: Deleted Document Logs"
+}

--- a/packages/sanity-toolkit/recycling-bin/schema.ts
+++ b/packages/sanity-toolkit/recycling-bin/schema.ts
@@ -1,0 +1,118 @@
+import { TrashIcon } from '@sanity/icons';
+import { defineArrayMember, defineField, defineType } from 'sanity';
+import { DeletedDocIdInputComponent } from './DeletedDocIdInputComponent';
+import { DeletionLogItemComponent } from './DeletionLogItemComponent';
+import { DeletionLogInputComponent } from './DeletionLogInputComponent';
+
+interface Options {
+  liveEdit?: boolean;
+}
+
+export function recyclingBinDocument(schemaName: string, { liveEdit = true }: Options = {}) {
+  return defineType({
+    name: schemaName,
+    title: 'Recycling Bin: Deleted Document Log',
+    type: 'document',
+    icon: TrashIcon,
+    liveEdit: liveEdit, // whether to skip a draft version of this document
+    // Fieldset to "hide away" the deletedDocIds array from view unless we need them
+    fieldsets: [
+      {
+        name: 'deletedDocIdLogs',
+        title: 'All Deleted Doc Id Logs',
+        options: {
+          collapsible: true,
+          collapsed: true,
+        },
+      },
+    ],
+    fields: [
+      // * Main log for restoring documents
+      defineField({
+        name: 'deletedDocLogs',
+        title: 'Deleted Doc Logs',
+        type: 'array',
+        readOnly: true,
+        options: {
+          sortable: false,
+        },
+        components: {
+          input: DeletionLogInputComponent,
+        },
+        description:
+          'Log of deleted documents. All items have the revision ID as the _key value and might have already been restored again.',
+        of: [
+          defineArrayMember({
+            type: 'object',
+            name: 'log',
+            title: 'Log',
+            readOnly: true,
+            components: {
+              // @ts-ignore
+              item: DeletionLogItemComponent,
+            },
+            fields: [
+              defineField({
+                name: 'docId',
+                title: 'Doc Id',
+                type: 'string',
+                validation: (Rule) => Rule.required(),
+              }),
+              defineField({
+                name: 'deletedAt',
+                title: 'Deleted At',
+                type: 'datetime',
+                validation: (Rule) => Rule.required(),
+              }),
+              defineField({
+                name: 'type',
+                title: 'Type',
+                type: 'string',
+              }),
+              defineField({
+                name: 'documentTitle',
+                title: 'Document Title',
+                type: 'string',
+                validation: (Rule) => Rule.required(),
+              }),
+            ],
+          }),
+        ],
+      }),
+      // Backup of all deleted doc ids
+      defineField({
+        name: 'deletedDocIds',
+        title: 'Deleted Doc Ids',
+        type: 'array',
+        readOnly: true,
+        options: {
+          sortable: false,
+        },
+        components: {
+          input: (props: { renderDefault: (arg0: any) => any }) =>
+            // Remove the `Add Item` button below the Array input
+            props.renderDefault({ ...props, arrayFunctions: () => null }),
+        },
+        fieldset: 'deletedDocIdLogs',
+        of: [
+          defineArrayMember({
+            name: 'deletedDocId',
+            type: 'string',
+            readOnly: true,
+            components: {
+              input: DeletedDocIdInputComponent,
+            },
+            validation: (Rule) => Rule.required(),
+          }),
+        ],
+      }),
+      // title for the document (will be set during creation via CLI)
+      defineField({
+        name: 'title',
+        title: 'Title',
+        type: 'string',
+        hidden: true,
+      }),
+    ],
+  });
+}

--- a/packages/sanity-toolkit/recycling-bin/types.ts
+++ b/packages/sanity-toolkit/recycling-bin/types.ts
@@ -1,0 +1,8 @@
+import type { ObjectItem } from 'sanity';
+
+export interface LogItem extends ObjectItem {
+  docId: string;
+  deletedAt: string;
+  type: string;
+  documentTitle: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       '@types/react':
         specifier: ^18
         version: 18.3.11
+      groq:
+        specifier: ^3.62.2
+        version: 3.62.2
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
@@ -301,9 +304,6 @@ importers:
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
-      groq:
-        specifier: ^3.62.2
-        version: 3.62.2
       happy-dom:
         specifier: ^15.7.4
         version: 15.7.4
@@ -8897,7 +8897,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.9
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)
 
   '@vitest/utils@2.1.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
+      groq:
+        specifier: ^3.62.2
+        version: 3.62.2
       happy-dom:
         specifier: ^15.7.4
         version: 15.7.4
@@ -8894,7 +8897,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.9
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)
+      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
 
   '@vitest/utils@2.1.4':
     dependencies:


### PR DESCRIPTION
# Context

A recycling bin allows users to restore documents they have deleted from elsewhere in the CMS.

# Overview

This PR adds a Recycling Bin to the Sanity Toolkit package. 

The Recycling Bin is based on [@bobinska-dev](https://github.com/bobinska-dev)'s recycling bin guide here: https://www.sanity.io/guides/bin-for-restoring-deleted-documents 

Closes #2