### PR TITLE
feat: add redirects document type

### DIFF
--- a/apps/sanity/config/schema.ts
+++ b/apps/sanity/config/schema.ts
@@ -3,7 +3,7 @@ import { DOCUMENT, SINGLETON } from '@pkg/common/constants/schemaTypes';
 /**
  * Document Types that should be shown in Internal Link fields, e.g. in Header Nav Menu.
  */
-export const INTERNAL_LINK_TYPES = [DOCUMENT.PAGE, DOCUMENT.ARTICLE];
+export const INTERNAL_LINK_TYPES = [DOCUMENT.PAGE];
 
 /**
  * Document types which:

--- a/apps/sanity/package.json
+++ b/apps/sanity/package.json
@@ -45,6 +45,7 @@
     "react-dom": "18.3.1",
     "react-icons": "5.3.0",
     "sanity": "3.61.0",
+    "sanity-plugin-note-field": "^2.0.2",
     "styled-components": "6.1.13",
     "vite": "5.4.9"
   },

--- a/apps/sanity/sanity.config.ts
+++ b/apps/sanity/sanity.config.ts
@@ -8,6 +8,7 @@ import { defaultDocumentNode } from '@/structure/defaultDocumentNode';
 import { appConfig } from './config/app';
 import { setupSingletons } from '@pkg/sanity-toolkit/studio/singletons';
 import { LOCKED_DOCUMENT_TYPES } from '@/config/schema';
+import { noteField } from 'sanity-plugin-note-field';
 
 export default defineConfig({
   name: 'default',
@@ -17,6 +18,7 @@ export default defineConfig({
   dataset: appConfig.dataset,
 
   plugins: [
+    noteField(),
     codeInput(),
     // Set up UI and logic for managing and editing Singleton documents
     setupSingletons(LOCKED_DOCUMENT_TYPES),

--- a/apps/sanity/schema/types/documents.ts
+++ b/apps/sanity/schema/types/documents.ts
@@ -1,4 +1,10 @@
 import { SchemaTypeDefinition } from 'sanity';
 import { page } from './documents/page';
+import { redirects } from '@pkg/sanity-toolkit/redirects/schema';
+import { DOCUMENT } from '@pkg/common/constants/schemaTypes';
+import { INTERNAL_LINK_TYPES } from '@/config/schema';
 
-export const documents: SchemaTypeDefinition[] = [page];
+export const documents: SchemaTypeDefinition[] = [
+  page,
+  redirects({ schemaName: DOCUMENT.CONFIG_REDIRECT, internalLinkTypes: INTERNAL_LINK_TYPES }),
+];

--- a/apps/sanity/structure/index.ts
+++ b/apps/sanity/structure/index.ts
@@ -162,27 +162,26 @@ export const structure: StructureResolver = (S, ctx) => {
       //         }),
       //       ]),
       //   ),
-      placeholder(S, 'Site Config', CogIcon),
-      // S.listItem()
-      //   .title('Site Config')
-      //   .icon(CogIcon)
-      //   .child(
-      //     S.list()
-      //       .title('Site Config')
-      //       .items([
-      //         singletonListItem(S, context, {
-      //           title: 'Active Theme',
-      //           schemaType: SINGLETON.THEME,
-      //         }),
-      //         S.divider(),
-      //         placeholder(S, 'Fallback Images', ImagesIcon),
-      //         S.documentTypeListItem(DOCUMENT.CONFIG_REDIRECT).title('Redirects'),
-      //         singletonListItem(S, context, {
-      //           title: 'SEO + Social Sharing',
-      //           schemaType: SINGLETON.CONFIG_SEO,
-      //         }),
-      //       ]),
-      //   ),
+      S.listItem()
+        .title('Site Config')
+        .icon(CogIcon)
+        .child(
+          S.list()
+            .title('Site Config')
+            .items([
+              // singletonListItem(S, context, {
+              //   title: 'Active Theme',
+              //   schemaType: SINGLETON.THEME,
+              // }),
+              // S.divider(),
+              // placeholder(S, 'Fallback Images', ImagesIcon),
+              S.documentTypeListItem(DOCUMENT.CONFIG_REDIRECT).title('Redirects'),
+              // singletonListItem(S, context, {
+              //   title: 'SEO + Social Sharing',
+              //   schemaType: SINGLETON.CONFIG_SEO,
+              // }),
+            ]),
+        ),
       S.divider(),
       singletonListItem(S, context, {
         title: 'Recycling Bin',

--- a/packages/sanity-toolkit/package.json
+++ b/packages/sanity-toolkit/package.json
@@ -24,6 +24,15 @@
     "test:unit": "vitest run",
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.2",
+    "@testing-library/react": "^16.0.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "@vitest/coverage-v8": "^2.1.4",
+    "@vitest/ui": "^2.1.4",
+    "happy-dom": "^15.7.4",
+    "vitest": "^2.1.4"
+  },
   "peerDependencies": {
     "@sanity/icons": "^3.4.0",
     "@sanity/types": "^3.61.0",
@@ -33,6 +42,7 @@
     "react": "^18",
     "react-icons": "^5.3.0",
     "sanity": "^3.60.0",
+    "sanity-plugin-note-field": "^2.0.2",
     "styled-components": "^6.1.13"
   },
   "dependencies": {
@@ -40,13 +50,9 @@
     "nanoid": "^5.0.7",
     "prettier": "^3.0.2"
   },
-  "devDependencies": {
-    "@testing-library/jest-dom": "^6.6.2",
-    "@testing-library/react": "^16.0.1",
-    "@vitejs/plugin-react": "^4.3.3",
-    "@vitest/coverage-v8": "^2.1.4",
-    "@vitest/ui": "^2.1.4",
-    "happy-dom": "^15.7.4",
-    "vitest": "^2.1.4"
+  "peerDependenciesMeta": {
+    "sanity-plugin-note-field": {
+      "optional": true
+    }
   }
 }

--- a/packages/sanity-toolkit/redirects/schema/defineRedirectFields.ts
+++ b/packages/sanity-toolkit/redirects/schema/defineRedirectFields.ts
@@ -1,0 +1,199 @@
+import { defineField } from 'sanity';
+import { AiOutlineWarning } from 'react-icons/ai';
+import { REDIRECT_TYPE } from '../types';
+import { isDeveloperOrAdmin } from '../../studio/utilities/roles';
+import {
+  linkMustBeRelativeOrAbsolute,
+  mustStartWith,
+  requiredIfParentIs,
+  shouldBeInternalLink,
+  validUrl,
+} from '../../studio/schema/validation';
+
+export function defineRedirectFields(internalLinkTypes: Array<string>) {
+  return [
+    defineField({
+      title: 'Redirect sources',
+      description:
+        'The incoming source path should not include the protocol or domain (https://domain.com). It must start with a "/". These are all valid: /path, /path/:slug, /path/:slug* and /path/(?!uk/).*',
+      name: 'redirectNote',
+      type: 'note',
+      options: {
+        icon: AiOutlineWarning,
+        tone: 'caution',
+      },
+    }),
+    defineField({
+      title: 'From path (slug)',
+      name: 'from',
+      type: 'string',
+      description: 'The incoming source path to match, e.g. "/path/to/page"',
+      validation: (rule) => [rule.required(), rule.custom(mustStartWith('/')).error()],
+    }),
+    defineField({
+      title: 'Link',
+      name: 'link',
+      type: 'object',
+      fieldsets: [
+        {
+          name: 'anchor',
+          title: 'Link to portion of page (anchor link)',
+          description: 'Optional',
+          hidden: ({ parent }: { parent?: { linkType?: REDIRECT_TYPE } }) =>
+            parent?.linkType !== REDIRECT_TYPE.DIRECT_PAGE,
+          options: {
+            collapsible: true,
+            collapsed: true,
+          },
+        },
+      ],
+      fields: [
+        defineField({
+          title: 'Link Type',
+          name: 'linkType',
+          type: 'string',
+          initialValue: REDIRECT_TYPE.DIRECT_PAGE,
+          options: {
+            layout: 'radio',
+            list: [
+              { title: 'Page', value: REDIRECT_TYPE.DIRECT_PAGE },
+              { title: 'Link', value: REDIRECT_TYPE.LINK },
+            ],
+          },
+        }),
+
+        /* Internal */
+        defineField({
+          title: 'Page',
+          name: 'page',
+          type: 'reference',
+          weak: true,
+          to: internalLinkTypes.map((docType) => ({ type: docType })),
+          hidden: ({ parent }: { parent?: { linkType?: REDIRECT_TYPE } }) =>
+            parent?.linkType !== REDIRECT_TYPE.DIRECT_PAGE,
+          validation: (rule) =>
+            rule.custom(requiredIfParentIs('linkType', REDIRECT_TYPE.DIRECT_PAGE)).error(),
+        }),
+        defineField({
+          title: 'Anchor tag',
+          name: 'pageAnchor',
+          type: 'string',
+          description:
+            'Enter an element "id" from the page. Do not start with "#". E.G. "section-one"',
+          fieldset: 'anchor',
+        }),
+
+        /* External */
+        defineField({
+          title: 'Link to an external page',
+          name: 'external',
+          type: 'string',
+          description:
+            "Either use a full URL (e.g. https://mydomain.com) or start with a / for a page on the site (e.g. /blog). Use the Page type if you're just linking to an internal page with no regex",
+          hidden: ({ parent }: { parent?: { linkType?: REDIRECT_TYPE } }) =>
+            parent?.linkType !== REDIRECT_TYPE.LINK,
+          validation: (rule) => [
+            rule
+              .custom((value) => !value || value.startsWith('/') || validUrl()(value))
+              .error(),
+            rule.custom(requiredIfParentIs('linkType', REDIRECT_TYPE.LINK)).error(),
+            rule.custom(linkMustBeRelativeOrAbsolute()).error(),
+            rule.custom(shouldBeInternalLink()).warning(),
+          ],
+        }),
+      ],
+    }),
+    defineField({
+      title: 'Is this a permanent (308) redirect?',
+      name: 'isPermanent',
+      type: 'boolean',
+      description:
+        'Turn this off if the redirect is temporary and you intend on removing it in the future. Keeping this on may mean the page From path can never be used again. Test the redirect first before setting to Permanent.',
+      initialValue: false,
+    }),
+    defineField({
+      title: 'Group',
+      name: 'group',
+      type: 'string',
+      description: 'Use groups to organise your redirects',
+      options: {
+        list: [
+          { title: 'Redirections', value: 'redirections' },
+          { title: 'Modified URLs', value: 'modifiedUrls' },
+        ],
+      },
+      initialValue: 'redirections',
+    }),
+    defineField({
+      title: 'Number of times redirected',
+      name: 'count',
+      type: 'number',
+      initialValue: 0,
+      readOnly: ({ currentUser }) => !isDeveloperOrAdmin(currentUser),
+    }),
+
+    // @todo This is not implemented in the server middleware, but is a good extensions for redirects
+    //       Left here for a future addition
+    // defineField({
+    //   title: 'Advanced',
+    //   name: 'advanced',
+    //   type: 'object',
+    //   description: 'Optional',
+    //   options: {
+    //     collapsible: true,
+    //     collapsed: true,
+    //   },
+    //   fields: [
+    //     defineField({
+    //       title: 'Header, Cookie, Host or Query matching',
+    //       name: 'matching',
+    //       type: 'array',
+    //       of: [
+    //         {
+    //           type: 'object',
+    //           name: 'match',
+    //           fields: [
+    //             {
+    //               type: 'string',
+    //               title: 'Has or Missing',
+    //               name: 'hasOrMissing',
+    //               options: {
+    //                 list: [
+    //                   { title: 'Has', value: 'has' },
+    //                   { title: 'Missing', value: 'missing' },
+    //                 ],
+    //               },
+    //               initialValue: 'has',
+    //             },
+    //             {
+    //               type: 'string',
+    //               title: 'Type',
+    //               name: 'type',
+    //               options: {
+    //                 list: [
+    //                   { title: 'Header', value: 'header' },
+    //                   { title: 'Cookie', value: 'cookie' },
+    //                   { title: 'Host', value: 'host' },
+    //                   { title: 'Query', value: 'query' },
+    //                 ],
+    //               },
+    //               initialValue: 'has',
+    //             },
+    //             {
+    //               type: 'string',
+    //               title: 'Key',
+    //               name: 'key',
+    //             },
+    //             {
+    //               type: 'string',
+    //               title: 'Value',
+    //               name: 'value',
+    //             },
+    //           ]
+    //         }
+    //       ],
+    //     })
+    //   ],
+    // })
+  ];
+}

--- a/packages/sanity-toolkit/redirects/schema/defineRedirectPreview.ts
+++ b/packages/sanity-toolkit/redirects/schema/defineRedirectPreview.ts
@@ -1,0 +1,34 @@
+import { REDIRECT_TYPE } from '../types';
+
+interface Prepare {
+  linkType?: REDIRECT_TYPE;
+  externalTo?: string;
+  internalTo?: string;
+  from?: string;
+  isPermanent?: boolean;
+}
+
+export function defineRedirectPreview() {
+  return {
+    select: {
+      linkType: 'link.linkType',
+      externalTo: 'link.external',
+      internalTo: 'link.internal.title',
+      from: 'from',
+      isPermanent: 'isPermanent',
+    },
+    prepare({ linkType, externalTo, internalTo, isPermanent, from }: Prepare) {
+      let title = 'New Redirect';
+      const to = linkType === REDIRECT_TYPE.DIRECT_PAGE ? internalTo : externalTo;
+
+      if (from ?? to) {
+        title = `${from ?? '?'} → ${to ?? '?'}`;
+      }
+
+      return {
+        title,
+        subtitle: isPermanent ? 'Permanent (308)' : 'Temporary (307)',
+      };
+    },
+  };
+}

--- a/packages/sanity-toolkit/redirects/schema/index.ts
+++ b/packages/sanity-toolkit/redirects/schema/index.ts
@@ -1,0 +1,20 @@
+import { defineType } from 'sanity';
+import { TbArrowElbowRight } from 'react-icons/tb';
+import { defineRedirectFields } from './defineRedirectFields';
+import { defineRedirectPreview } from './defineRedirectPreview';
+
+interface Options {
+  schemaName: string;
+  internalLinkTypes: Array<string>;
+}
+
+export function redirects({ schemaName, internalLinkTypes }: Options) {
+  return defineType({
+    title: 'Redirect',
+    name: schemaName,
+    type: 'document',
+    icon: TbArrowElbowRight,
+    fields: defineRedirectFields(internalLinkTypes),
+    preview: defineRedirectPreview(),
+  });
+}

--- a/packages/sanity-toolkit/redirects/types/index.ts
+++ b/packages/sanity-toolkit/redirects/types/index.ts
@@ -1,0 +1,4 @@
+export enum REDIRECT_TYPE {
+  DIRECT_PAGE = 'directPage',
+  LINK = 'link',
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       sanity:
         specifier: 3.61.0
         version: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      sanity-plugin-note-field:
+        specifier: ^2.0.2
+        version: 2.0.2(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       styled-components:
         specifier: 6.1.13
         version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5316,6 +5319,13 @@ packages:
     resolution: {integrity: sha512-I1vTrgbZxhJhoR8Gystc8naTvtBH2nSg+hOyrnoMWLk3lpweSCBTBzg6I80NCRi6y9HzclnoNaFPMxkgwFfbQw==}
     engines: {node: '>=14.18'}
 
+  sanity-plugin-note-field@2.0.2:
+    resolution: {integrity: sha512-Dbjm3FwL50PjDrgY7Sxa3DiR2yMWHm88IzmuGoj2EVY8KIZ0YUfwKc9oqT1l4GzI8jRZZ2ySoMxUOcWUq4BqpA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^18
+      sanity: ^3
+
   sanity@3.61.0:
     resolution: {integrity: sha512-1m/W3i0TNjbkPLhIK7YsJ1MepiyFJGI0i9JVINvNyTiZISdN7JnLJu7n78pBd+CI4i95WB8zxAJdOFQ4I7cPyg==}
     engines: {node: '>=18'}
@@ -8897,7 +8907,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.9
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)
+      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
 
   '@vitest/utils@2.1.4':
     dependencies:
@@ -12127,6 +12137,19 @@ snapshots:
   sanity-diff-patch@3.0.4:
     dependencies:
       '@sanity/diff-match-patch': 3.1.1
+
+  sanity-plugin-note-field@2.0.2(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@sanity/ui': 1.9.3(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.3.1
+      sanity: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+    transitivePeerDependencies:
+      - react-dom
+      - react-is
+      - styled-components
 
   sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       sanity:
         specifier: ^3.60.0
         version: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      sanity-plugin-note-field:
+        specifier: ^2.0.2
+        version: 2.0.2(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       styled-components:
         specifier: ^6.1.13
         version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8907,7 +8910,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.9
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)
 
   '@vitest/utils@2.1.4':
     dependencies:


### PR DESCRIPTION
# Context

The CMS should provide editors with the ability to add and edit redirects, as well as test them.

# Overview

This PR adds a Redirect document type.

Redirects have a From path, which can optionally include wildcards (`*`) and capture groups (`:slug`). It also supports some limited regex. These are all valid: `/path`, `/path/:slug`, `/path/:slug*` and `/path/(?!uk/).*`

It then takes a To, either as an internal page reference or as a URL. If an internal page is chosen, a further optional field for adding query parameters or an anchor ID is shown, to append to the URL.

The redirect can be a 308 (permanent) or a 307 (temporary). These are typically preferred over 301 and 302, as they don't alter the http method used when redirecting.

Lastly, the redirect can be attributed to a specific group, to help categorise them, and a count of how many times the redirect has been triggered can be recorded.

<img width="451" alt="image" src="https://github.com/user-attachments/assets/097f494a-257a-4e0b-b9a3-994492d12e58">

The frontend integration will come later on, and should ensure that query parameters and/or an anchor ID are correctly passed through to the To link, and merged with any query parameters specified on the To link. Any conflicting query parameters should be overridden by those specified on the redirect. Same for the anchor ID.
