### PR TITLE
feat(seo-config): add global SEO and social sharing config

### DIFF
--- a/apps/sanity/schema/types/singletons.ts
+++ b/apps/sanity/schema/types/singletons.ts
@@ -2,7 +2,9 @@ import { SchemaTypeDefinition } from 'sanity';
 import { recyclingBinDocument } from '@pkg/sanity-toolkit/recycling-bin/schema';
 import { SINGLETON } from '@pkg/common/constants/schemaTypes';
 import { appConfig } from '@/config/app';
+import { configSeo } from '@/schema/types/singletons/configSeo';
 
 export const singletons: SchemaTypeDefinition[] = [
+  configSeo,
   recyclingBinDocument(SINGLETON.RECYCLING_BIN, { apiVersion: appConfig.apiVersion }),
 ];

--- a/apps/sanity/schema/types/singletons/configSeo.ts
+++ b/apps/sanity/schema/types/singletons/configSeo.ts
@@ -40,7 +40,7 @@ export const configSeo = defineType({
       name: 'siteTitle',
       type: 'string',
       description:
-        'Prominently shown on the browser tab, on search engine results, and social sharing. Often appended or prepended to meta titles, e.g. Meta Title | Site Title',
+        'Prominently shown on the browser tab, on search engine results, and social sharing. Often appended or prepended to page titles, e.g. Page Title | Site Title',
       group: 'general',
     }),
     defineField({
@@ -54,7 +54,7 @@ export const configSeo = defineType({
       validation: (rule) => rule.required().uri({ scheme: ['http', 'https'] }),
     }),
     defineField({
-      title: 'Prepend or Append Site Title to Meta Title?',
+      title: 'Prepend or Append Site Title to Page Title?',
       name: 'withSiteTitle',
       type: 'string',
       description: 'Do not turn this off unless you understand the SEO impact',
@@ -70,10 +70,10 @@ export const configSeo = defineType({
       fieldset: 'titleMeta',
     }),
     defineField({
-      title: 'Choose selector to separate Site Title and Meta Title',
+      title: 'Choose selector to separate Site Title and Page Title',
       name: 'titleSeparator',
       type: 'string',
-      description: 'This will show between the site title and the meta title',
+      description: 'This will show between the site title and the page title',
       hidden: ({ document }) => document?.withSiteTitle === 'off',
       group: 'general',
       options: {

--- a/apps/sanity/schema/types/singletons/configSeo.ts
+++ b/apps/sanity/schema/types/singletons/configSeo.ts
@@ -1,0 +1,119 @@
+import { BiSearch } from 'react-icons/bi';
+import { defineField, defineType } from 'sanity';
+import { SINGLETON } from '@pkg/common/constants/schemaTypes';
+import { defineSeoFields } from '@/features/seo/schema/defineSeoFields';
+import { withProps } from '@pkg/sanity-toolkit/studio/schema/utilities';
+import { seoFieldset, WITH_SITE_TITLE } from '@pkg/sanity-toolkit/seo';
+import { defineSingletonTitle } from '@pkg/sanity-toolkit/studio/singletons';
+import { isDeveloperOrAdmin } from '@pkg/sanity-toolkit/studio/utilities/roles';
+
+const title = 'SEO + Social';
+
+export const configSeo = defineType({
+  name: SINGLETON.CONFIG_SEO,
+  title,
+  type: 'document',
+  icon: BiSearch,
+  fieldsets: [
+    seoFieldset({ global: true }),
+    { name: 'titleMeta', title: 'Title Meta', options: { columns: 2 } },
+    { name: 'favicon', title: 'Icons', options: { columns: 2 } },
+    { name: 'dev', title: 'Dev', options: { collapsed: true, collapsible: true } },
+  ],
+  groups: [
+    {
+      title: 'General',
+      name: 'general',
+    },
+    {
+      title: 'SEO',
+      name: 'seo',
+    },
+    {
+      title: 'Icons',
+      name: 'icons',
+    },
+  ],
+  fields: [
+    defineField({
+      title: 'Site Title',
+      name: 'siteTitle',
+      type: 'string',
+      description:
+        'Prominently shown on the browser tab, on search engine results, and social sharing. Often appended or prepended to meta titles, e.g. Meta Title | Site Title',
+      group: 'general',
+    }),
+    defineField({
+      title: 'Site URL',
+      name: 'siteUrl',
+      type: 'url',
+      description:
+        'The website URL used for canonical URLs. Should include protocol and full domain name. E.G. https://domain.com',
+      group: 'general',
+      readOnly: ({ currentUser }) => !isDeveloperOrAdmin(currentUser),
+      validation: (rule) => rule.required().uri({ scheme: ['http', 'https'] }),
+    }),
+    defineField({
+      title: 'Prepend or Append Site Title to Meta Title?',
+      name: 'withSiteTitle',
+      type: 'string',
+      description: 'Do not turn this off unless you understand the SEO impact',
+      group: 'general',
+      options: {
+        list: [
+          { title: 'Prepend', value: WITH_SITE_TITLE.PREPEND },
+          { title: 'Append', value: WITH_SITE_TITLE.APPEND },
+          { title: 'Off', value: WITH_SITE_TITLE.OFF },
+        ],
+      },
+      initialValue: WITH_SITE_TITLE.APPEND,
+      fieldset: 'titleMeta',
+    }),
+    defineField({
+      title: 'Choose selector to separate Site Title and Meta Title',
+      name: 'titleSeparator',
+      type: 'string',
+      description: 'This will show between the site title and the meta title',
+      hidden: ({ document }) => document?.withSiteTitle === 'off',
+      group: 'general',
+      options: {
+        list: [
+          { title: '|', value: '|' },
+          { title: '-', value: '-' },
+          { title: '–', value: '–' },
+          { title: '—', value: '—' },
+          { title: '•', value: '•' },
+        ],
+      },
+      initialValue: '|',
+      fieldset: 'titleMeta',
+    }),
+
+    ...withProps({ group: 'seo' }, [...defineSeoFields()]),
+
+    defineField({
+      title: 'Browser Icon (Favicon)',
+      name: 'favicon',
+      type: 'image',
+      description:
+        'Shown on browser tabs and Google search results. Should be a square image, ideally 512x512 PNG or 16x16 SVG',
+      group: 'icons',
+      options: {
+        accept: 'image/svg+xml, image/png, image/webp',
+        sources: [],
+      },
+      fieldset: 'favicon',
+    }),
+
+    {
+      ...defineSingletonTitle(title),
+      fieldset: 'dev',
+    },
+  ],
+  preview: {
+    prepare: () => ({
+      title,
+      subtitle: 'Site Config',
+    }),
+  },
+});

--- a/apps/sanity/structure/index.ts
+++ b/apps/sanity/structure/index.ts
@@ -178,10 +178,10 @@ export const structure: StructureResolver = (S, ctx) => {
               // S.divider(),
               // placeholder(S, 'Fallback Images', ImagesIcon),
               S.documentTypeListItem(DOCUMENT.CONFIG_REDIRECT).title('Redirects'),
-              // singletonListItem(S, context, {
-              //   title: 'SEO + Social Sharing',
-              //   schemaType: SINGLETON.CONFIG_SEO,
-              // }),
+              singletonListItem(S, context, {
+                title: 'SEO + Social Sharing',
+                schemaType: SINGLETON.CONFIG_SEO,
+              }),
             ]),
         ),
       S.divider(),

--- a/packages/sanity-toolkit/seo/index.ts
+++ b/packages/sanity-toolkit/seo/index.ts
@@ -1,0 +1,4 @@
+export * from './constants';
+export * from './schema/defineSeoFields';
+export * from './schema/defineVisibilityField';
+export * from './schema/seoFieldset';


### PR DESCRIPTION
# Context

Marketing and editorial teams need to be able to manage the global SEO options of their website.

# Overview

This PR creates a new Singleton called "SEO + Social Sharing". It lives under "Site Config" in the structure.

It provides the global defaults for SEO. The fields can be seen in the image below. This config will later be merged with page-level SEO data to provide the final SEO for that page. It also allows users to set the website favicon, and the site URL that will be used by other tools, such as live preview and FE URL generation

<img width="351" alt="image" src="https://github.com/user-attachments/assets/b51e2d8d-6540-4034-b588-415f1b6a3842">
