### PR TITLE
feat(seo-preview): add SEO preview pane to Config SEO and Pages

### DIFF
--- a/apps/sanity/structure/defaultViews.ts
+++ b/apps/sanity/structure/defaultViews.ts
@@ -5,7 +5,8 @@ import {
   ViewBuilder,
 } from 'sanity/structure';
 import { LuPencilLine } from 'react-icons/lu';
-import { isDeveloperOrAdmin } from '@pkg/sanity-toolkit/studio/utilities/roles';
+import { seoPreviewPane } from '@/structure/seo-pane';
+import { SEO_PREVIEW_DOCUMENT_TYPES } from '@/config/schema';
 
 export function defaultViews(
   S: StructureBuilder,
@@ -17,9 +18,9 @@ export function defaultViews(
   //   views.push(previewPane(S, context, options.apiVersion));
   // }
 
-  // if (SEO_PREVIEW_DOCUMENT_TYPES.includes(context.schemaType)) {
-  //   views.push(seoPreviewPane(S));
-  // }
+  if (SEO_PREVIEW_DOCUMENT_TYPES.includes(context.schemaType)) {
+    views.push(seoPreviewPane(S));
+  }
 
   // if (INCOMING_REFERENCE_LIST.includes(context.schemaType)) {
   //   views.push(backlinksPane(S));

--- a/apps/sanity/structure/index.ts
+++ b/apps/sanity/structure/index.ts
@@ -18,6 +18,7 @@ import { skeletonKey } from '@pkg/sanity-toolkit/studio/structure/skeletonKey';
 import { isDeveloperOrAdmin } from '@pkg/sanity-toolkit/studio/utilities/roles';
 import { LuUnlink } from 'react-icons/lu';
 import { FaUserPen } from 'react-icons/fa6';
+import { defaultViews } from '@/structure/defaultViews';
 
 // Add anything we need available to all structure functions to this type (such as locale)
 export type StructureContext = StructureResolverContext;
@@ -56,6 +57,9 @@ const DOCUMENT_TYPES_IN_STRUCTURE: Array<string> = [
 export const structure: StructureResolver = (S, ctx) => {
   // Add anything we need available to all structure functions to this variable (such as locale)
   const context: StructureContext = ctx;
+
+  const singletonDefaultViews = (documentId: string, schemaType: string) =>
+    defaultViews(S, { documentId, schemaType, ...context });
 
   // See: https://www.sanity.io/docs/structure-builder-reference
   return S.list()
@@ -181,6 +185,7 @@ export const structure: StructureResolver = (S, ctx) => {
               singletonListItem(S, context, {
                 title: 'SEO + Social Sharing',
                 schemaType: SINGLETON.CONFIG_SEO,
+                defaultViews: singletonDefaultViews,
               }),
             ]),
         ),

--- a/apps/sanity/structure/seo-pane/components/SeoPreviewPane.tsx
+++ b/apps/sanity/structure/seo-pane/components/SeoPreviewPane.tsx
@@ -1,0 +1,88 @@
+import { BsFacebook, BsGoogle } from 'react-icons/bs';
+import { RiTwitterXFill } from 'react-icons/ri';
+import {
+  SeoPreviewCard,
+  GoogleSearchResult,
+  TwitterCardPreview,
+  FacebookSharePreview,
+} from '@pkg/sanity-toolkit/seo-preview/components';
+import { combineSeo } from '../utilities/combineSeo';
+import { useSiteConfigSeo } from '../hooks/useSiteConfigSeo';
+import { SeoFields } from '@/types';
+
+interface Options {
+  apiVersion?: string;
+  configSeo?: ConfigSeo;
+}
+
+interface Props {
+  document: {
+    displayed?: SeoFields & {
+      _type: string;
+      pathname?: { current: string };
+    };
+  };
+}
+
+interface ConfigSeo {
+  id: string;
+  type: string;
+}
+
+export function SeoPreviewPaneFn({ apiVersion = '2024-10-24', configSeo }: Options) {
+  return function SeoPreviewPane({ document }: Props) {
+    const [siteConfigSeo, loading] = useSiteConfigSeo({ apiVersion });
+
+    const seo = combineSeo(
+      siteConfigSeo,
+      document.displayed ?? {},
+      document.displayed?.pathname?.current,
+    );
+
+    return (
+      <>
+        <SeoPreviewCard
+          loading={loading}
+          canShowPreview={!!seo.pageTitle}
+          type={'Google search result'}
+          Icon={BsGoogle}
+          intent={configSeo}
+        >
+          <GoogleSearchResult
+            favicon={seo.favicon}
+            siteTitle={seo.siteTitle ?? seo.siteUrl}
+            pageUrl={seo.pageTitle ?? seo.siteUrl}
+            pageTitle={seo.pageTitle}
+            description={seo.metaDescription}
+          />
+        </SeoPreviewCard>
+
+        <SeoPreviewCard
+          loading={loading}
+          canShowPreview={!!seo.shareImage}
+          type={'Twitter / X post'}
+          Icon={RiTwitterXFill}
+          intent={configSeo}
+        >
+          <TwitterCardPreview shareImage={seo.shareImage} siteUrl={seo.siteUrl} />
+        </SeoPreviewCard>
+
+        <SeoPreviewCard
+          loading={loading}
+          canShowPreview={!!seo.pageTitle}
+          type={'Facebook share'}
+          Icon={BsFacebook}
+          intent={configSeo}
+        >
+          <FacebookSharePreview
+            shareImage={seo.shareImage}
+            siteUrl={seo.siteUrl}
+            pageUrl={seo.pageUrl}
+            pageTitle={seo.pageTitle}
+            metaDescription={seo.metaDescription}
+          />
+        </SeoPreviewCard>
+      </>
+    );
+  };
+}

--- a/apps/sanity/structure/seo-pane/hooks/useSiteConfigSeo.ts
+++ b/apps/sanity/structure/seo-pane/hooks/useSiteConfigSeo.ts
@@ -1,0 +1,61 @@
+import { useClient } from 'sanity';
+import { useEffect, useState } from 'react';
+import { SINGLETON } from '@pkg/common/constants/schemaTypes';
+import { WITH_SITE_TITLE } from '@pkg/sanity-toolkit/seo';
+import { ConfigSeoSocial } from '@/types';
+
+const initialSiteConfigSeo: ConfigSeoSocial = { withSiteTitle: WITH_SITE_TITLE.APPEND };
+
+interface Options {
+  apiVersion?: string;
+}
+
+export function useSiteConfigSeo({
+  apiVersion = '2024-10-31',
+}: Options): [ConfigSeoSocial, boolean] {
+  const sanityClient = useClient({ apiVersion });
+  const [siteConfigSeo, setSiteConfigSeo] = useState<ConfigSeoSocial>({
+    ...initialSiteConfigSeo,
+  });
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let shouldUpdateSeo = true;
+
+    async function getSiteConfigSeo() {
+      let seo = await sanityClient.fetch<ConfigSeoSocial | null>(`
+        *[_type == "${SINGLETON.CONFIG_SEO}"][0] {
+          siteTitle,
+          siteUrl,
+          withSiteTitle,
+          titleSeparator,
+          pageTitle,
+          metaDescription,
+          "socialImage": socialImage.asset,
+          favicon,
+        }
+      `);
+
+      if (!seo) {
+        // In case default SEO data hasn't been set, returned data would be null
+        seo = { ...initialSiteConfigSeo };
+      }
+
+      if (shouldUpdateSeo) {
+        // Ensure we only update once with latest call, even if useEffect runs multiple times quickly
+        setSiteConfigSeo(seo);
+        setLoading(false);
+      }
+    }
+
+    getSiteConfigSeo().catch((err: unknown) => {
+      console.error(err);
+    });
+
+    return () => {
+      shouldUpdateSeo = false;
+    };
+  }, [sanityClient, initialSiteConfigSeo]);
+
+  return [siteConfigSeo, loading];
+}

--- a/apps/sanity/structure/seo-pane/index.ts
+++ b/apps/sanity/structure/seo-pane/index.ts
@@ -1,0 +1,18 @@
+import type { StructureBuilder } from 'sanity/structure';
+import { BiSearch } from 'react-icons/bi';
+import { SeoPreviewPaneFn } from './components/SeoPreviewPane';
+import { appConfig } from '@/config/app';
+import { SINGLETON } from '@pkg/common/constants/schemaTypes';
+import { singletonDocId } from '@pkg/sanity-toolkit/studio/singletons';
+
+export function seoPreviewPane(S: StructureBuilder) {
+  const SeoPreviewPane = SeoPreviewPaneFn({
+    apiVersion: appConfig.apiVersion,
+    configSeo: {
+      id: singletonDocId(SINGLETON.CONFIG_SEO),
+      type: SINGLETON.CONFIG_SEO,
+    },
+  });
+
+  return S.view.component(SeoPreviewPane).title('SEO Preview').icon(BiSearch);
+}

--- a/apps/sanity/structure/seo-pane/types/index.ts
+++ b/apps/sanity/structure/seo-pane/types/index.ts
@@ -1,0 +1,15 @@
+import type { Image } from 'sanity';
+
+/**
+ * The SEO Data once it has been combined from a page and the site config fallbacks.
+ * Used in the SEO Preview pane.
+ */
+export interface SeoDataCombined {
+  siteUrl?: string | null;
+  siteTitle?: string | null;
+  pageUrl?: string | null;
+  pageTitle?: string | null;
+  metaDescription?: string | null;
+  shareImage?: Image | null;
+  favicon?: Image | null;
+}

--- a/apps/sanity/structure/seo-pane/utilities/combineSeo.ts
+++ b/apps/sanity/structure/seo-pane/utilities/combineSeo.ts
@@ -1,0 +1,34 @@
+import { WITH_SITE_TITLE } from '@pkg/sanity-toolkit/seo';
+import { ConfigSeoSocial, SeoFields } from '@/types';
+import { SeoDataCombined } from '@/structure/seo-pane/types';
+
+/**
+ * Combines the default seo data from Site Config: SEO + Social, with seo data from
+ * an individual page.
+ */
+export function combineSeo(
+  defaultSeo: ConfigSeoSocial,
+  pageSeo: SeoFields,
+  pathname = '',
+): SeoDataCombined {
+  let pageTitle = pageSeo.pageTitle ?? defaultSeo.pageTitle;
+
+  if (defaultSeo.withSiteTitle && pageTitle !== defaultSeo.siteTitle && defaultSeo.siteTitle) {
+    if (defaultSeo.withSiteTitle === WITH_SITE_TITLE.PREPEND) {
+      pageTitle = `${defaultSeo.siteTitle} ${defaultSeo.titleSeparator} ${pageTitle}`;
+    }
+    if (defaultSeo.withSiteTitle === WITH_SITE_TITLE.APPEND) {
+      pageTitle = `${pageTitle} ${defaultSeo.titleSeparator} ${defaultSeo.siteTitle}`;
+    }
+  }
+
+  return {
+    favicon: defaultSeo.favicon,
+    siteUrl: defaultSeo.siteUrl ?? '',
+    shareImage: pageSeo.socialImage ?? defaultSeo.socialImage, // meta share image OR default share image
+    siteTitle: defaultSeo.siteTitle ?? '',
+    pageUrl: `${defaultSeo.siteUrl}${pathname}`,
+    pageTitle: pageTitle ?? '',
+    metaDescription: pageSeo.metaDescription ?? defaultSeo.metaDescription ?? '',
+  };
+}

--- a/apps/sanity/types/index.ts
+++ b/apps/sanity/types/index.ts
@@ -1,0 +1,22 @@
+import { WITH_SITE_TITLE } from '@pkg/sanity-toolkit/seo';
+import { Image } from 'sanity';
+import type { SeoFields as ToolkitSeoFields } from '@pkg/sanity-toolkit/seo/types';
+
+/**
+ * The SEO fields defined for all pages, and for the global SEO fallback.
+ */
+export interface SeoFields extends ToolkitSeoFields {
+  pathname?: { current: string };
+}
+
+/**
+ * The SEO fields defined in Site Config > SEO + Social
+ */
+export interface ConfigSeoSocial extends SeoFields {
+  siteTitle?: string | null;
+  siteUrl?: string | null;
+  withSiteTitle?: WITH_SITE_TITLE;
+  titleSeparator?: string;
+
+  favicon?: Image | null;
+}

--- a/packages/sanity-toolkit/css.d.ts
+++ b/packages/sanity-toolkit/css.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/packages/sanity-toolkit/package.json
+++ b/packages/sanity-toolkit/package.json
@@ -31,10 +31,12 @@
     "@vitest/coverage-v8": "^2.1.4",
     "@vitest/ui": "^2.1.4",
     "happy-dom": "^15.7.4",
+    "typescript-plugin-css-modules": "^5.1.0",
     "vitest": "^2.1.4"
   },
   "peerDependencies": {
     "@sanity/icons": "^3.4.0",
+    "@sanity/image-url": "^1.0.2",
     "@sanity/types": "^3.61.0",
     "@sanity/ui": "^2.8.9",
     "@types/react": "^18",

--- a/packages/sanity-toolkit/seo-preview/components/SeoPreviewCard.tsx
+++ b/packages/sanity-toolkit/seo-preview/components/SeoPreviewCard.tsx
@@ -6,7 +6,7 @@ interface Props {
   loading: boolean;
   canShowPreview: boolean;
   type: string;
-  Icon: React.ComponentType<{ className: string }>;
+  Icon: React.ComponentType<{ className?: string }>;
   intent?: {
     id: string;
     type: string;

--- a/packages/sanity-toolkit/seo-preview/components/SeoPreviewCard.tsx
+++ b/packages/sanity-toolkit/seo-preview/components/SeoPreviewCard.tsx
@@ -1,0 +1,57 @@
+import preview from './previews/Preview.module.css';
+import { IntentLink } from 'sanity/router';
+
+interface Props {
+  children: React.ReactNode;
+  loading: boolean;
+  canShowPreview: boolean;
+  type: string;
+  Icon: React.ComponentType<{ className: string }>;
+  intent?: {
+    id: string;
+    type: string;
+  };
+}
+
+export function SeoPreviewCard({
+  loading,
+  canShowPreview,
+  children,
+  Icon,
+  type,
+  intent,
+}: Props) {
+  const loadingHtml = (
+    <div>
+      <strong>Loading</strong>
+    </div>
+  );
+  const previewHtml = <div className={preview.seoItemCard}>{children}</div>;
+  const cantShowPreviewHtml = (
+    <div style={{ color: 'black' }}>
+      <strong>Not enough data to show preview</strong>
+      <p>
+        Please add a title or image, and fill out your SEO fields first, on this content or in{' '}
+        <IntentLink intent="edit" params={intent}>
+          Site Config &gt; SEO + Social.
+        </IntentLink>
+      </p>
+    </div>
+  );
+
+  const outputHtml = loading
+    ? loadingHtml
+    : !canShowPreview
+      ? cantShowPreviewHtml
+      : previewHtml;
+
+  return (
+    <div className={preview.seoItem}>
+      <h3 className={preview.seoItemTitle}>
+        <Icon className={preview.seoItemLogo} />
+        {type} preview
+      </h3>
+      <div className={preview.seoItemContent}>{outputHtml}</div>
+    </div>
+  );
+}

--- a/packages/sanity-toolkit/seo-preview/components/index.ts
+++ b/packages/sanity-toolkit/seo-preview/components/index.ts
@@ -1,0 +1,4 @@
+export * from './SeoPreviewCard';
+export * from './previews/FacebookSharePreview/FacebookSharePreview';
+export * from './previews/GoogleSearchResult/GoogleSearchResult';
+export * from './previews/TwitterCardPreview/TwitterCardPreview';

--- a/packages/sanity-toolkit/seo-preview/components/previews/FacebookSharePreview/FacebookSharePreview.module.css
+++ b/packages/sanity-toolkit/seo-preview/components/previews/FacebookSharePreview/FacebookSharePreview.module.css
@@ -1,0 +1,66 @@
+/* Facebook Share */
+.facebookWrapper {
+  max-width: 100%;
+  background-color: #f6f6f6;
+  overflow: hidden;
+}
+
+.facebookImageContainer {
+  display: flex;
+  width: 100%;
+  overflow: hidden;
+}
+
+.facebookCardImage {
+  width: 100%;
+  object-fit: cover;
+}
+
+.facebookCardContent {
+  padding: 10px 12px;
+  background: rgb(240, 242, 245);
+  color: #606770;
+  border: 1px solid #ced0d4;
+}
+
+.facebookCardUrl {
+  flex-shrink: 0;
+  margin-bottom: 4px;
+  padding: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  line-height: 16px;
+  text-transform: uppercase;
+  color: rgb(101, 103, 107);
+}
+
+.facebookCardTitle {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+  overflow: hidden;
+}
+
+.facebookCardTitle a {
+  color: #1d2129;
+  font-family: inherit;
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 20px;
+  margin: 3px 0 0;
+  padding-top: 2px;
+  text-decoration: none;
+}
+
+.facebookCardDescription {
+  color: rgb(101, 103, 107);
+  font-size: 15px;
+  line-height: 20px;
+  max-height: 80px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+  overflow: hidden;
+}

--- a/packages/sanity-toolkit/seo-preview/components/previews/FacebookSharePreview/FacebookSharePreview.tsx
+++ b/packages/sanity-toolkit/seo-preview/components/previews/FacebookSharePreview/FacebookSharePreview.tsx
@@ -1,0 +1,59 @@
+import imageUrlBuilder from '@sanity/image-url';
+import preview from '../Preview.module.css';
+import facebook from './FacebookSharePreview.module.css';
+import { type Image, useClient } from 'sanity';
+
+interface Props {
+  shareImage?: null | Image;
+  siteTitle?: null | string;
+  siteUrl?: null | string;
+  pageUrl?: null | string;
+  pageTitle?: null | string;
+  metaDescription?: null | string;
+  width?: number;
+}
+
+export function FacebookSharePreview({
+  shareImage,
+  siteUrl,
+  pageUrl,
+  pageTitle,
+  metaDescription,
+  width = 580,
+}: Props) {
+  const sanityClient = useClient({ apiVersion: '2024-04-26' });
+  const imageBuilder = imageUrlBuilder(sanityClient);
+  const urlFor = (source: Image) => imageBuilder.image(source);
+
+  const shareUrl = siteUrl ? siteUrl.split('://')[1] : '';
+
+  // const canShowPreview = !!pageTitle;
+
+  return (
+    <div className={facebook.facebookWrapper} style={{ width }}>
+      <div className={facebook.facebookImageContainer}>
+        {shareImage ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            alt="share on facebook"
+            className={facebook.facebookCardImage}
+            src={urlFor(shareImage).width(1200).height(630).url()}
+          />
+        ) : (
+          <span className={preview.imagePlaceholder} />
+        )}
+      </div>
+      <div className={facebook.facebookCardContent}>
+        <div className={facebook.facebookCardUrl}>{shareUrl}</div>
+        <div className={facebook.facebookCardTitle}>
+          <a href={pageUrl ?? '#'} target="_blank" rel="noreferrer">
+            {pageTitle}
+          </a>
+        </div>
+        {metaDescription && (
+          <div className={facebook.facebookCardDescription}>{metaDescription}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/sanity-toolkit/seo-preview/components/previews/GoogleSearchResult/GoogleSearchResult.module.css
+++ b/packages/sanity-toolkit/seo-preview/components/previews/GoogleSearchResult/GoogleSearchResult.module.css
@@ -1,0 +1,72 @@
+.googleWrapper {
+  -webkit-font-smoothing: initial;
+  font-family: Arial, sans-serif;
+  max-width: 100%;
+}
+
+.googleTitle {
+  color: #1a0dab;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1.3;
+  margin-top: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.googleTitle:hover {
+  text-decoration: underline;
+}
+
+.googleUrl {
+  color: #202124;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.googleUrl span {
+  color: #5f6368;
+}
+
+.googleDesc {
+  color: #4d5156;
+  font-size: 14px;
+  line-height: 1.58;
+  word-wrap: break-word;
+}
+
+.googleUrlBar {
+  align-items: center;
+  display: flex;
+}
+
+.googleFaviconContainer {
+  align-items: center;
+  background-color: #f1f3f4;
+  border: 1px solid #ecedef;
+  border-radius: 50%;
+  display: inline-flex;
+  height: 26px;
+  justify-content: center;
+  margin-right: 12px;
+  vertical-align: middle;
+  width: 26px;
+}
+
+.googleFaviconImage {
+  object-fit: cover;
+  width: 100%;
+}
+
+.googleSiteTitle {
+  color: #1a0d0d;
+  font-size: 14px;
+  line-height: 20px;
+}

--- a/packages/sanity-toolkit/seo-preview/components/previews/GoogleSearchResult/GoogleSearchResult.tsx
+++ b/packages/sanity-toolkit/seo-preview/components/previews/GoogleSearchResult/GoogleSearchResult.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { type Image, useClient } from 'sanity';
+import imageUrlBuilder from '@sanity/image-url';
+import google from './GoogleSearchResult.module.css';
+
+interface Props {
+  favicon?: null | Image;
+  siteTitle?: null | string;
+  pageUrl?: null | string;
+  pageTitle?: null | string;
+  description?: null | string;
+  width?: number;
+}
+
+export function GoogleSearchResult({
+  favicon,
+  siteTitle,
+  pageUrl,
+  pageTitle,
+  description,
+  width = 580,
+}: Props) {
+  const sanityClient = useClient({ apiVersion: '2024-04-26' });
+  const imageBuilder = imageUrlBuilder(sanityClient);
+  const urlFor = (source: Image) => imageBuilder.image(source);
+
+  return (
+    <div className={google.googleWrapper} style={{ width }}>
+      <div className={google.googleUrlBar}>
+        <div className={google.googleFaviconContainer}>
+          {favicon ? (
+            <img
+              className={google.googleFaviconImage}
+              alt="google search"
+              src={urlFor(favicon).width(52).height(52).url()}
+            />
+          ) : (
+            <span />
+          )}
+        </div>
+        <div>
+          <div className={google.googleSiteTitle}>{siteTitle}</div>
+          <div className={google.googleUrl}>{pageUrl}</div>
+        </div>
+      </div>
+      <div className={google.googleTitle}>{pageTitle}</div>
+
+      {description && <div className={google.googleDesc}>{description}</div>}
+    </div>
+  );
+}

--- a/packages/sanity-toolkit/seo-preview/components/previews/Preview.module.css
+++ b/packages/sanity-toolkit/seo-preview/components/previews/Preview.module.css
@@ -1,0 +1,70 @@
+.seoItem {
+  --title-padding: 1rem;
+  --title-font-size: 1rem;
+  --title-line-height: 1.25;
+
+  --content-padding: 1.5rem;
+  --content-bg-color: rgb(247, 247, 247);
+  --content-border-color: rgba(86, 89, 94, 0.25);
+  --card-border-radius: 6px;
+
+  --image-placeholder-bg-color: rgb(137, 139, 142);
+}
+
+.seoItem {
+  margin: 0;
+}
+
+.seoItemTitle {
+  align-items: center;
+  display: flex;
+  margin: 0;
+  padding: var(--title-padding);
+  font-size: var(--title-font-size);
+  line-height: var(--title-line-height);
+}
+
+.seoItemLogo {
+  margin-right: 16px;
+}
+
+.seoItemContent {
+  display: flex;
+  overflow: auto;
+  padding: var(--content-padding);
+  background-color: var(--content-bg-color);
+  border-top: 1px solid var(--content-border-color);
+  border-bottom: 1px solid var(--content-border-color);
+}
+
+.seoItemCard {
+  margin: 0 !important;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #fff;
+  border: 1px solid rgb(171, 172, 175);
+  padding: 1rem;
+  min-width: 460px;
+  border-radius: var(--card-border-radius);
+}
+
+/* Image Placeholder */
+.imagePlaceholder {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-top: 52.5%;
+  background: var(--image-placeholder-bg-color);
+}
+
+.imagePlaceholder::after {
+  content: 'no photo set!';
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  text-align: center;
+  transform: translateY(-50%);
+}

--- a/packages/sanity-toolkit/seo-preview/components/previews/TwitterCardPreview/TwitterCardPreview.module.css
+++ b/packages/sanity-toolkit/seo-preview/components/previews/TwitterCardPreview/TwitterCardPreview.module.css
@@ -1,0 +1,161 @@
+/* Twitter Preview */
+.tweetWrapper {
+  position: relative;
+  max-width: 100%;
+  padding: 12px 12px 8px 55px;
+  text-align: left;
+  font-size: 14px;
+  box-sizing: border-box;
+  background-color: #fff;
+}
+
+.tweetAuthor {
+  position: relative;
+  margin-right: 75px;
+  margin-bottom: 2px;
+}
+
+.tweetAuthorAvatar {
+  position: absolute;
+  top: 0;
+  left: -55px;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+}
+
+.tweetAuthorName {
+  margin-right: 4px;
+  font-weight: 700;
+  color: #333;
+}
+
+.tweetAuthorHandle {
+  padding: 0;
+  margin-top: 2px;
+  margin-left: 2px;
+  font-size: 12px;
+  color: rgb(91, 112, 131);
+}
+
+.tweetText p {
+  color: #333;
+  margin: 0 0 10px;
+}
+
+.tweetUrlWrapper {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.tweetCardPreview {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  border-color: rgb(196, 207, 214);
+  border-radius: 16px;
+  border-width: 1px;
+  border-style: solid;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+    sans-serif;
+}
+
+.tweetCardContent {
+  padding: 0.75em;
+  width: calc(100% - 8.81667em - 2px);
+  overflow: hidden;
+}
+
+.tweetCardImage {
+  display: flex;
+  border-right-width: 1px;
+  overflow: hidden;
+  width: 100%;
+  flex-shrink: 0;
+}
+
+.tweetCardImage img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.tweetCardTitle {
+  max-height: 1.3em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 1em;
+  font-weight: normal;
+  margin: 0 0 0.15em;
+}
+
+.tweetCardDescription {
+  max-height: 3.9em;
+  overflow: hidden;
+  color: rgb(91, 112, 131);
+}
+
+.tweetCardDescription p {
+  overflow: hidden;
+  margin-top: 0.32333em;
+}
+
+.tweetCardDestination {
+  margin-top: 0.32333em;
+  text-transform: lowercase;
+  color: rgb(91, 112, 131);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tweetCardIcon {
+  margin-right: 2px;
+  height: 1.25em;
+  font-size: 12px;
+  line-height: calc(18.375px);
+  color: rgb(91, 112, 131);
+}
+
+.tweetCardIcon svg {
+  display: inline-block;
+  vertical-align: text-bottom;
+  height: 1.25em;
+  fill: currentColor;
+}
+
+/* v2 - Musk removes headline */
+.tweetCardImage {
+  position: relative;
+}
+
+.tweetCardUrl {
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+  bottom: 12px;
+  color: #fff;
+  font-size: 13px;
+  line-height: 16px;
+  font-family:
+    'TwitterChirp',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
+  left: 12px;
+  padding-left: 4px;
+  padding-right: 4px;
+  position: absolute;
+  pointer-events: none;
+  text-align: center;
+  word-wrap: break-word;
+}
+/* End v2 */

--- a/packages/sanity-toolkit/seo-preview/components/previews/TwitterCardPreview/TwitterCardPreview.tsx
+++ b/packages/sanity-toolkit/seo-preview/components/previews/TwitterCardPreview/TwitterCardPreview.tsx
@@ -1,0 +1,79 @@
+import imageUrlBuilder from '@sanity/image-url';
+import twitter from './TwitterCardPreview.module.css';
+import { type Image } from 'sanity';
+import { useClient } from 'sanity';
+
+interface Props {
+  shareImage?: null | Image;
+  siteUrl?: null | string;
+  width?: number;
+}
+
+const author = {
+  name: 'Hex Digital',
+  handle: 'hexdigital',
+  image: 'https://pbs.twimg.com/profile_images/1066311597499576320/Xt-AkciA_400x400.jpg',
+};
+
+export function TwitterCardPreview({ shareImage, siteUrl, width = 580 }: Props) {
+  const sanityClient = useClient({ apiVersion: '2024-04-26' });
+  const imageBuilder = imageUrlBuilder(sanityClient);
+  const urlFor = (source: Image) => imageBuilder.image(source);
+
+  // const canShowPreview = !!shareImage;
+
+  return (
+    <div className={twitter.tweetWrapper} style={{ width }}>
+      <div className={twitter.tweetAuthor}>
+        <img
+          alt={'tweet author ' + author.name}
+          className={twitter.tweetAuthorAvatar}
+          src={
+            typeof author.image === 'object'
+              ? urlFor(author.image).width(300).url()
+              : author.image
+          }
+        />
+        <span className={twitter.tweetAuthorName}>{author.name}</span>
+        <span className={twitter.tweetAuthorHandle}>@{author.handle}</span>
+      </div>
+
+      <div className={twitter.tweetText}>
+        <p>Tweet about this...</p>
+      </div>
+      <div className={twitter.tweetUrlWrapper}>
+        <div className={twitter.tweetCardPreview}>
+          <div className={twitter.tweetCardImage}>
+            {shareImage && (
+              <img
+                alt="share on twitter"
+                src={urlFor(shareImage).width(1200).height(630).url()}
+              />
+            )}
+            <span className={twitter.tweetCardUrl}>{siteUrl}</span>
+          </div>
+          {/* Musk removed all this recently. Might get reverted... https://variety.com/2023/digital/news/x-twitter-removes-headlines-from-articles-musk-esthetics-1235745719/*/}
+          {/*<div className={twitter.tweetCardContent}>*/}
+          {/*  <h2 className={twitter.tweetCardTitle}>{shareTitle}</h2>*/}
+          {/*  {shareDesc && (*/}
+          {/*    <div className={twitter.tweetCardDescription}>*/}
+          {/*      {shareDesc}*/}
+          {/*    </div>*/}
+          {/*  )}*/}
+          {/*  <div className={twitter.tweetCardDestination}>*/}
+          {/*      <span className={twitter.tweetCardIcon}>*/}
+          {/*        <svg viewBox="0 0 24 24">*/}
+          {/*          <g>*/}
+          {/*            <path d="M11.96 14.945c-.067 0-.136-.01-.203-.027-1.13-.318-2.097-.986-2.795-1.932-.832-1.125-1.176-2.508-.968-3.893s.942-2.605 2.068-3.438l3.53-2.608c2.322-1.716 5.61-1.224 7.33 1.1.83 1.127 1.175 2.51.967 3.895s-.943 2.605-2.07 3.438l-1.48 1.094c-.333.246-.804.175-1.05-.158-.246-.334-.176-.804.158-1.05l1.48-1.095c.803-.592 1.327-1.463 1.476-2.45.148-.988-.098-1.975-.69-2.778-1.225-1.656-3.572-2.01-5.23-.784l-3.53 2.608c-.802.593-1.326 1.464-1.475 2.45-.15.99.097 1.975.69 2.778.498.675 1.187 1.15 1.992 1.377.4.114.633.528.52.928-.092.33-.394.547-.722.547z" />*/}
+          {/*            <path d="M7.27 22.054c-1.61 0-3.197-.735-4.225-2.125-.832-1.127-1.176-2.51-.968-3.894s.943-2.605 2.07-3.438l1.478-1.094c.334-.245.805-.175 1.05.158s.177.804-.157 1.05l-1.48 1.095c-.803.593-1.326 1.464-1.475 2.45-.148.99.097 1.975.69 2.778 1.225 1.657 3.57 2.01 5.23.785l3.528-2.608c1.658-1.225 2.01-3.57.785-5.23-.498-.674-1.187-1.15-1.992-1.376-.4-.113-.633-.527-.52-.927.112-.4.528-.63.926-.522 1.13.318 2.096.986 2.794 1.932 1.717 2.324 1.224 5.612-1.1 7.33l-3.53 2.608c-.933.693-2.023 1.026-3.105 1.026z" />*/}
+          {/*          </g>*/}
+          {/*        </svg>*/}
+          {/*      </span>*/}
+          {/*    {websiteUrlWithoutProtocol}*/}
+          {/*  </div>*/}
+          {/*</div>*/}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/sanity-toolkit/seo/constants/index.ts
+++ b/packages/sanity-toolkit/seo/constants/index.ts
@@ -6,7 +6,7 @@ export enum PAGE_VISIBILITY {
 export const SEO_FIELDSET = 'seoSocial';
 
 export enum SEO_FIELD {
-  META_TITLE = 'metaTitle',
+  PAGE_TITLE = 'pageTitle',
   META_DESCRIPTION = 'metaDescription',
   SOCIAL_IMAGE = 'socialImage',
 }

--- a/packages/sanity-toolkit/seo/schema/defineSeoFields.ts
+++ b/packages/sanity-toolkit/seo/schema/defineSeoFields.ts
@@ -31,7 +31,7 @@ export function defineSeoFields(options: Options = {}) {
   return [
     defineSuperStringField({
       title: metaTitleTitle,
-      name: SEO_FIELD.META_TITLE,
+      name: SEO_FIELD.PAGE_TITLE,
       description:
         'Make it as enticing as possible to capture users in Google + social feeds. If it matches the Site Title, only one will be displayed to prevent duplication.',
       options: {

--- a/packages/sanity-toolkit/seo/types/index.ts
+++ b/packages/sanity-toolkit/seo/types/index.ts
@@ -1,0 +1,12 @@
+import type { Image } from 'sanity';
+import { SEO_FIELD } from '../constants';
+
+/**
+ * The SEO fields defined for all pages, and for the global SEO fallback.
+ */
+export interface SeoFields {
+  [SEO_FIELD.PAGE_TITLE]?: string | null;
+  [SEO_FIELD.META_DESCRIPTION]?: string | null;
+  [SEO_FIELD.SOCIAL_IMAGE]?: Image | null;
+  pathname?: { current: string };
+}

--- a/packages/sanity-toolkit/studio/structure/singletonListItem.ts
+++ b/packages/sanity-toolkit/studio/structure/singletonListItem.ts
@@ -31,6 +31,9 @@ export function singletonListItem(
 
   const itemTitle = title ?? documentSchema?.title ?? 'Unnamed';
 
+  const views =
+    typeof defaultViews == 'function' ? defaultViews(documentId, schemaType) : defaultViews;
+
   return S.listItem()
     .id(documentId)
     .title(itemTitle)
@@ -42,6 +45,6 @@ export function singletonListItem(
         .title(viewTitle ?? itemTitle)
         .schemaType(schemaType)
         .documentId(documentId)
-        .views(defaultViews ?? []),
+        .views(views ?? []),
     );
 }

--- a/packages/sanity-toolkit/studio/types/index.ts
+++ b/packages/sanity-toolkit/studio/types/index.ts
@@ -7,5 +7,7 @@ export interface SingletonListItem {
   viewTitle?: string;
   icon?: ComponentType | ReactNode;
   isPrivate?: boolean;
-  defaultViews?: Array<View | ViewBuilder>;
+  defaultViews?:
+    | Array<View | ViewBuilder>
+    | ((documentId: string, schemaType: string) => Array<View | ViewBuilder>);
 }

--- a/packages/sanity-toolkit/tsconfig.json
+++ b/packages/sanity-toolkit/tsconfig.json
@@ -9,7 +9,8 @@
     "jsx": "react-jsx",
     "noEmit": false,
     "incremental": true,
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "plugins": [{ "name": "typescript-plugin-css-modules" }]
   },
   "exclude": ["**/node_modules", "**/.*/*"],
   "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: link:../../packages/utilities
       '@sanity/code-input':
         specifier: 4.1.4
-        version: 4.1.4(@babel/runtime@7.25.7)(@codemirror/lint@6.8.2)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.2.3)(codemirror@6.0.1(@lezer/common@1.2.3))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.1.4(@babel/runtime@7.25.7)(@codemirror/lint@6.8.2)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.2.3)(codemirror@6.0.1(@lezer/common@1.2.3))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/icons':
         specifier: 3.4.0
         version: 3.4.0(react@18.3.1)
@@ -88,16 +88,16 @@ importers:
         version: 5.3.0(react@18.3.1)
       sanity:
         specifier: 3.61.0
-        version: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0)
       sanity-plugin-note-field:
         specifier: ^2.0.2
-        version: 2.0.2(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 2.0.2(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       styled-components:
         specifier: 6.1.13
         version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite:
         specifier: 5.4.9
-        version: 5.4.9(@types/node@20.16.14)
+        version: 5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
     devDependencies:
       '@sanity/eslint-config-studio':
         specifier: 4.0.0
@@ -110,7 +110,7 @@ importers:
         version: 18.3.11
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0))
+        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
@@ -125,13 +125,13 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)
+        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
   apps/web:
     dependencies:
       next:
         specifier: 14.2.15
-        version: 14.2.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -156,7 +156,7 @@ importers:
         version: 18.3.1
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1))
+        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
@@ -177,7 +177,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
   packages/common:
     dependencies:
@@ -187,19 +187,19 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1))
+        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
   packages/config:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1))
+        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
@@ -211,7 +211,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
   packages/modular-content-blocks:
     dependencies:
@@ -232,7 +232,7 @@ importers:
         version: 5.3.0(react@18.3.1)
       sanity:
         specifier: ^3.60.0
-        version: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0)
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.0
@@ -242,16 +242,16 @@ importers:
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.9(@types/node@20.16.14))
+        version: 4.3.3(vite@5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1))
+        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
   packages/sanity-toolkit:
     dependencies:
@@ -261,6 +261,9 @@ importers:
       '@sanity/icons':
         specifier: ^3.4.0
         version: 3.4.0(react@18.3.1)
+      '@sanity/image-url':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@sanity/types':
         specifier: ^3.61.0
         version: 3.61.0(debug@4.3.7)
@@ -303,19 +306,22 @@ importers:
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.9(@types/node@20.16.14))
+        version: 4.3.3(vite@5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1))
+        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
       happy-dom:
         specifier: ^15.7.4
         version: 15.7.4
+      typescript-plugin-css-modules:
+        specifier: ^5.1.0
+        version: 5.1.0(typescript@5.6.3)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
   packages/utilities:
     dependencies:
@@ -334,15 +340,18 @@ importers:
         version: 13.0.6
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1))
+        version: 2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/ui':
         specifier: ^2.1.4
         version: 2.1.4(vitest@2.1.4)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+        version: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
 packages:
+
+  '@adobe/css-tools@4.3.3':
+    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
 
   '@adobe/css-tools@4.4.0':
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
@@ -1643,6 +1652,82 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@parcel/watcher-android-arm64@2.4.1':
+    resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.4.1':
+    resolution: {integrity: sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.4.1':
+    resolution: {integrity: sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.4.1':
+    resolution: {integrity: sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.4.1':
+    resolution: {integrity: sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-glibc@2.4.1':
+    resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-musl@2.4.1':
+    resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-glibc@2.4.1':
+    resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-musl@2.4.1':
+    resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-win32-arm64@2.4.1':
+    resolution: {integrity: sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.4.1':
+    resolution: {integrity: sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.4.1':
+    resolution: {integrity: sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.4.1':
+    resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
+    engines: {node: '>= 10.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2106,6 +2191,12 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/postcss-modules-local-by-default@4.0.2':
+    resolution: {integrity: sha512-CtYCcD+L+trB3reJPny+bKWKMzPfxEyQpKIwit7kErnOexf5/faaGpkFy4I5AwbV4hp1sk7/aTg0tt0B67VkLQ==}
+
+  '@types/postcss-modules-scope@3.0.4':
+    resolution: {integrity: sha512-//ygSisVq9kVI0sqx3UPLzWIMCmtSVrzdljtuaAEJtGoGnpjBikZ2sXO5MpH9SnWX9HRfXxHifDAXcQjupWnIQ==}
 
   '@types/progress-stream@2.0.5':
     resolution: {integrity: sha512-5YNriuEZkHlFHHepLIaxzq3atGeav1qCTGzB74HKWpo66qjfostF+rHc785YYYHeBytve8ZG3ejg42jEIfXNiQ==}
@@ -2687,6 +2778,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -2829,6 +2924,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  copy-anything@2.0.6:
+    resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
 
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
@@ -3058,6 +3156,11 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
@@ -3113,6 +3216,10 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
+
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
@@ -3163,6 +3270,10 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  errno@0.1.8:
+    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
+    hasBin: true
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -3824,6 +3935,12 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  icss-utils@5.1.0:
+    resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -3831,8 +3948,16 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  image-size@0.5.5:
+    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
+
+  immutable@4.3.7:
+    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
 
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -4090,6 +4215,9 @@ packages:
     resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
     engines: {node: '>= 0.4'}
 
+  is-what@3.14.1:
+    resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
+
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
@@ -4257,6 +4385,11 @@ packages:
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
+
+  less@4.2.0:
+    resolution: {integrity: sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -4448,6 +4581,11 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -4552,6 +4690,11 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  needle@3.3.1:
+    resolution: {integrity: sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==}
+    engines: {node: '>= 4.4.x'}
+    hasBin: true
+
   next@14.2.15:
     resolution: {integrity: sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==}
     engines: {node: '>=18.17.0'}
@@ -4569,6 +4712,9 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -4784,6 +4930,10 @@ packages:
     resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
     engines: {node: '>=6'}
 
+  parse-node-version@1.0.1:
+    resolution: {integrity: sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==}
+    engines: {node: '>= 0.10'}
+
   parse5@7.2.0:
     resolution: {integrity: sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==}
 
@@ -4917,6 +5067,18 @@ packages:
     peerDependencies:
       postcss: ^8.4.21
 
+  postcss-load-config@3.1.4:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+
   postcss-load-config@4.0.2:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
@@ -4928,6 +5090,24 @@ packages:
         optional: true
       ts-node:
         optional: true
+
+  postcss-modules-extract-imports@3.1.0:
+    resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+
+  postcss-modules-local-by-default@4.0.5:
+    resolution: {integrity: sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+
+  postcss-modules-scope@3.2.0:
+    resolution: {integrity: sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
 
   postcss-nested@6.2.0:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
@@ -5003,6 +5183,9 @@ packages:
 
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
+
+  prr@1.0.1:
+    resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -5173,6 +5356,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -5222,6 +5409,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reserved-words@0.1.2:
+    resolution: {integrity: sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -5337,6 +5527,17 @@ packages:
       react: ^18
       react-dom: ^18
       styled-components: ^6.1
+
+  sass@1.80.5:
+    resolution: {integrity: sha512-TQd2aoQl/+zsxRMEDSxVdpPIqeq9UFc6pr7PzkugiTx3VYCFPUaa3P4RrBQsqok4PO200Vkz0vXQBNlg7W907g==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  sax@1.3.0:
+    resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
+
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -5462,6 +5663,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
 
   space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -5625,6 +5830,10 @@ packages:
 
   stylis@4.3.2:
     resolution: {integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==}
+
+  stylus@0.62.0:
+    resolution: {integrity: sha512-v3YCf31atbwJQIMtPNX8hcQ+okD4NQaTuKGUWfII8eaqn+3otrbttGL1zSMZAAtiPsBztQnujVBugg/cXFUpyg==}
+    hasBin: true
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -5907,6 +6116,11 @@ packages:
 
   typeid-js@0.3.0:
     resolution: {integrity: sha512-A1EmvIWG6xwYRfHuYUjPltHqteZ1EiDG+HOmbIYXeHUVztmnGrPIfU9KIK1QC30x59ko0r4JsMlwzsALCyiB3Q==}
+
+  typescript-plugin-css-modules@5.1.0:
+    resolution: {integrity: sha512-6h+sLBa4l+XYSTn/31vZHd/1c3SvAbLpobY6FxDiUOHJQG1eD9Gh3eCs12+Eqc+TCOAdxcO+zAPvUq0jBfdciw==}
+    peerDependencies:
+      typescript: '>=4.0.0'
 
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
@@ -6266,6 +6480,10 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+
   yaml@2.5.1:
     resolution: {integrity: sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==}
     engines: {node: '>= 14'}
@@ -6307,6 +6525,8 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
+
+  '@adobe/css-tools@4.3.3': {}
 
   '@adobe/css-tools@4.4.0': {}
 
@@ -7884,6 +8104,62 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@parcel/watcher-android-arm64@2.4.1':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.4.1':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.4.1':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.4.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.4.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.4.1':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.4.1':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.4.1':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.4.1':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.4.1':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.4.1':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.4.1':
+    optional: true
+
+  '@parcel/watcher@2.4.1':
+    dependencies:
+      detect-libc: 1.0.3
+      is-glob: 4.0.3
+      micromatch: 4.0.8
+      node-addon-api: 7.1.1
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.4.1
+      '@parcel/watcher-darwin-arm64': 2.4.1
+      '@parcel/watcher-darwin-x64': 2.4.1
+      '@parcel/watcher-freebsd-x64': 2.4.1
+      '@parcel/watcher-linux-arm-glibc': 2.4.1
+      '@parcel/watcher-linux-arm64-glibc': 2.4.1
+      '@parcel/watcher-linux-arm64-musl': 2.4.1
+      '@parcel/watcher-linux-x64-glibc': 2.4.1
+      '@parcel/watcher-linux-x64-musl': 2.4.1
+      '@parcel/watcher-win32-arm64': 2.4.1
+      '@parcel/watcher-win32-ia32': 2.4.1
+      '@parcel/watcher-win32-x64': 2.4.1
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -8040,7 +8316,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/code-input@4.1.4(@babel/runtime@7.25.7)(@codemirror/lint@6.8.2)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.2.3)(codemirror@6.0.1(@lezer/common@1.2.3))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@sanity/code-input@4.1.4(@babel/runtime@7.25.7)(@codemirror/lint@6.8.2)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.2.3)(codemirror@6.0.1(@lezer/common@1.2.3))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@codemirror/autocomplete': 6.18.1(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
       '@codemirror/commands': 6.7.1
@@ -8064,7 +8340,7 @@ snapshots:
       '@uiw/react-codemirror': 4.23.5(@babel/runtime@7.25.7)(@codemirror/autocomplete@6.18.1(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3))(@codemirror/language@6.10.3)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.34.1)(codemirror@6.0.1(@lezer/common@1.2.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      sanity: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      sanity: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0)
       styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -8573,6 +8849,14 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/postcss-modules-local-by-default@4.0.2':
+    dependencies:
+      postcss: 8.4.47
+
+  '@types/postcss-modules-scope@3.0.4':
+    dependencies:
+      postcss: 8.4.47
+
   '@types/progress-stream@2.0.5':
     dependencies:
       '@types/node': 20.16.14
@@ -8809,6 +9093,17 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
+  '@vitejs/plugin-react@4.3.3(vite@4.5.5(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/plugin-transform-react-jsx-self': 7.25.7(@babel/core@7.25.8)
+      '@babel/plugin-transform-react-jsx-source': 7.25.7(@babel/core@7.25.8)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 4.5.5(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-react@4.3.3(vite@4.5.5(@types/node@20.16.14))':
     dependencies:
       '@babel/core': 7.25.8
@@ -8820,18 +9115,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.3(vite@5.4.9(@types/node@20.16.14))':
+  '@vitejs/plugin-react@4.3.3(vite@5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))':
     dependencies:
       '@babel/core': 7.25.8
       '@babel/plugin-transform-react-jsx-self': 7.25.7(@babel/core@7.25.8)
       '@babel/plugin-transform-react-jsx-source': 7.25.7(@babel/core@7.25.8)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.9(@types/node@20.16.14)
+      vite: 5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0))':
+  '@vitest/coverage-v8@2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -8845,11 +9140,11 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)
+      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1))':
+  '@vitest/coverage-v8@2.1.4(vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -8863,7 +9158,7 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)
+      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8874,13 +9169,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.4(vite@5.4.9(@types/node@20.16.14))':
+  '@vitest/mocker@2.1.4(vite@5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))':
     dependencies:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      vite: 5.4.9(@types/node@20.16.14)
+      vite: 5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
   '@vitest/pretty-format@2.1.4':
     dependencies:
@@ -8910,7 +9205,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.9
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)
+      vitest: 2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
 
   '@vitest/utils@2.1.4':
     dependencies:
@@ -9309,6 +9604,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.1:
+    dependencies:
+      readdirp: 4.0.2
+
   chownr@1.1.4: {}
 
   chownr@3.0.0: {}
@@ -9457,6 +9756,10 @@ snapshots:
       split2: 4.2.0
 
   convert-source-map@2.0.0: {}
+
+  copy-anything@2.0.6:
+    dependencies:
+      is-what: 3.14.1
 
   copy-to-clipboard@3.3.3:
     dependencies:
@@ -9683,6 +9986,8 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
+  detect-libc@1.0.3: {}
+
   detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
@@ -9733,6 +10038,8 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  dotenv@16.4.5: {}
+
   dotenv@8.6.0: {}
 
   duplexify@3.7.1:
@@ -9780,6 +10087,11 @@ snapshots:
   env-paths@2.2.1: {}
 
   environment@1.1.0: {}
+
+  errno@0.1.8:
+    dependencies:
+      prr: 1.0.1
+    optional: true
 
   error-ex@1.3.2:
     dependencies:
@@ -10669,11 +10981,20 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  icss-utils@5.1.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
+  image-size@0.5.5:
+    optional: true
+
   immer@10.1.1: {}
+
+  immutable@4.3.7: {}
 
   import-fresh@3.3.0:
     dependencies:
@@ -10876,6 +11197,8 @@ snapshots:
       call-bind: 1.0.7
       get-intrinsic: 1.2.4
 
+  is-what@3.14.1: {}
+
   is-windows@1.0.2: {}
 
   is-wsl@2.2.0:
@@ -11068,6 +11391,20 @@ snapshots:
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
+
+  less@4.2.0:
+    dependencies:
+      copy-anything: 2.0.6
+      parse-node-version: 1.0.1
+      tslib: 2.8.0
+    optionalDependencies:
+      errno: 0.1.8
+      graceful-fs: 4.2.11
+      image-size: 0.5.5
+      make-dir: 2.1.0
+      mime: 1.6.0
+      needle: 3.3.1
+      source-map: 0.6.1
 
   leven@3.1.0: {}
 
@@ -11263,6 +11600,9 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mime@1.6.0:
+    optional: true
+
   mimic-fn@2.1.0: {}
 
   mimic-fn@4.0.0: {}
@@ -11351,7 +11691,13 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  needle@3.3.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      sax: 1.4.1
+    optional: true
+
+  next@14.2.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5):
     dependencies:
       '@next/env': 14.2.15
       '@swc/helpers': 0.5.5
@@ -11372,9 +11718,12 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.15
       '@next/swc-win32-ia32-msvc': 14.2.15
       '@next/swc-win32-x64-msvc': 14.2.15
+      sass: 1.80.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-addon-api@7.1.1: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -11610,6 +11959,8 @@ snapshots:
 
   parse-ms@2.1.0: {}
 
+  parse-node-version@1.0.1: {}
+
   parse5@7.2.0:
     dependencies:
       entities: 4.5.0
@@ -11703,12 +12054,35 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.47
 
+  postcss-load-config@3.1.4(postcss@8.4.47):
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.4.47
+
   postcss-load-config@4.0.2(postcss@8.4.47):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.6.0
     optionalDependencies:
       postcss: 8.4.47
+
+  postcss-modules-extract-imports@3.1.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+
+  postcss-modules-local-by-default@4.0.5(postcss@8.4.47):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.47)
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+
+  postcss-modules-scope@3.2.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
 
   postcss-nested@6.2.0(postcss@8.4.47):
     dependencies:
@@ -11783,6 +12157,9 @@ snapshots:
   property-information@5.6.0:
     dependencies:
       xtend: 4.0.2
+
+  prr@1.0.1:
+    optional: true
 
   pseudomap@1.0.2: {}
 
@@ -11968,6 +12345,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  readdirp@4.0.2: {}
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -12028,6 +12407,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
+
+  reserved-words@0.1.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -12141,6 +12522,19 @@ snapshots:
     dependencies:
       '@sanity/diff-match-patch': 3.1.1
 
+  sanity-plugin-note-field@2.0.2(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@sanity/ui': 1.9.3(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.3.1
+      sanity: 3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0)
+    transitivePeerDependencies:
+      - react-dom
+      - react-is
+      - styled-components
+
   sanity-plugin-note-field@2.0.2(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12153,6 +12547,142 @@ snapshots:
       - react-dom
       - react-is
       - styled-components
+
+  sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.5)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0):
+    dependencies:
+      '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      '@juggle/resize-observer': 3.4.0
+      '@portabletext/editor': 1.1.5(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0(debug@4.3.7))(@sanity/util@3.61.0(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@portabletext/react': 3.1.0(react@18.3.1)
+      '@rexxars/react-json-inspector': 8.0.1(react@18.3.1)
+      '@sanity/asset-utils': 2.0.6
+      '@sanity/bifur-client': 0.4.1
+      '@sanity/block-tools': 3.61.0(debug@4.3.7)
+      '@sanity/cli': 3.61.0(react@18.3.1)
+      '@sanity/client': 6.22.2(debug@4.3.7)
+      '@sanity/color': 3.0.6
+      '@sanity/diff': 3.61.0
+      '@sanity/diff-match-patch': 3.1.1
+      '@sanity/eventsource': 5.0.2
+      '@sanity/export': 3.41.0
+      '@sanity/icons': 3.4.0(react@18.3.1)
+      '@sanity/image-url': 1.0.2
+      '@sanity/import': 3.37.8
+      '@sanity/insert-menu': 1.0.9(@sanity/types@3.61.0(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
+      '@sanity/migrate': 3.61.0
+      '@sanity/mutator': 3.61.0
+      '@sanity/presentation': 1.16.5(@sanity/client@6.22.2(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/schema': 3.61.0(debug@4.3.7)
+      '@sanity/telemetry': 0.7.9(react@18.3.1)
+      '@sanity/types': 3.61.0(debug@4.3.7)
+      '@sanity/ui': 2.8.9(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/util': 3.61.0(debug@4.3.7)
+      '@sanity/uuid': 3.0.2
+      '@sentry/react': 8.35.0(react@18.3.1)
+      '@tanstack/react-table': 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual': 3.0.0-beta.54(react@18.3.1)
+      '@types/react-copy-to-clipboard': 5.0.7
+      '@types/react-is': 18.3.0
+      '@types/shallow-equals': 1.0.3
+      '@types/speakingurl': 13.0.6
+      '@types/tar-stream': 3.1.3
+      '@types/use-sync-external-store': 0.0.6
+      '@vitejs/plugin-react': 4.3.3(vite@4.5.5(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
+      archiver: 7.0.1
+      arrify: 1.0.1
+      async-mutex: 0.4.1
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      classnames: 2.5.1
+      color2k: 2.0.3
+      configstore: 5.0.1
+      connect-history-api-fallback: 1.6.0
+      console-table-printer: 2.12.1
+      dataloader: 2.2.2
+      date-fns: 2.30.0
+      debug: 4.3.7
+      esbuild: 0.21.5
+      esbuild-register: 3.6.0(esbuild@0.21.5)
+      execa: 2.1.0
+      exif-component: 1.0.1
+      form-data: 4.0.1
+      framer-motion: 11.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      get-it: 8.6.5(debug@4.3.7)
+      get-random-values-esm: 1.0.2
+      groq-js: 1.13.0
+      history: 5.3.0
+      i18next: 23.16.2
+      import-fresh: 3.3.0
+      is-hotkey-esm: 1.0.0
+      jsdom: 23.2.0
+      jsdom-global: 3.0.2(jsdom@23.2.0)
+      json-lexer: 1.2.0
+      json-reduce: 3.0.0
+      json5: 2.2.3
+      lodash: 4.17.21
+      log-symbols: 2.2.0
+      mendoza: 3.0.7
+      module-alias: 2.2.3
+      nano-pubsub: 3.0.0
+      nanoid: 3.3.7
+      node-html-parser: 6.1.13
+      observable-callback: 1.0.3(rxjs@7.8.1)
+      oneline: 1.0.3
+      open: 8.4.2
+      p-map: 7.0.2
+      pirates: 4.0.6
+      pluralize-esm: 9.0.5
+      polished: 4.3.1
+      pretty-ms: 7.0.1
+      quick-lru: 5.1.1
+      raf: 3.4.1
+      react: 18.3.1
+      react-copy-to-clipboard: 5.1.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.2(@types/react@18.3.11)(react@18.3.1)
+      react-i18next: 14.0.2(i18next@23.16.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-is: 18.3.1
+      react-refractor: 2.2.0(react@18.3.1)
+      react-rx: 4.0.0(react@18.3.1)(rxjs@7.8.1)
+      read-pkg-up: 7.0.1
+      refractor: 3.6.0
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.2
+      rimraf: 3.0.2
+      rxjs: 7.8.1
+      rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.1)
+      sanity-diff-patch: 3.0.4
+      scroll-into-view-if-needed: 3.1.0
+      semver: 7.6.3
+      shallow-equals: 1.0.0
+      speakingurl: 14.0.1
+      styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tar-fs: 2.1.1
+      tar-stream: 3.1.7
+      use-device-pixel-ratio: 1.1.2(react@18.3.1)
+      use-hot-module-reload: 2.0.0(react@18.3.1)
+      use-sync-external-store: 1.2.2(react@18.3.1)
+      vite: 4.5.5(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - bufferutil
+      - canvas
+      - less
+      - lightningcss
+      - react-native
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - utf-8-validate
 
   sanity@3.61.0(@types/node@20.16.14)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -12290,6 +12820,18 @@ snapshots:
       - terser
       - utf-8-validate
 
+  sass@1.80.5:
+    dependencies:
+      '@parcel/watcher': 2.4.1
+      chokidar: 4.0.1
+      immutable: 4.3.7
+      source-map-js: 1.2.1
+
+  sax@1.3.0: {}
+
+  sax@1.4.1:
+    optional: true
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -12414,6 +12956,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  source-map@0.7.4: {}
 
   space-separated-tokens@1.1.5: {}
 
@@ -12590,6 +13134,16 @@ snapshots:
       react: 18.3.1
 
   stylis@4.3.2: {}
+
+  stylus@0.62.0:
+    dependencies:
+      '@adobe/css-tools': 4.3.3
+      debug: 4.3.7
+      glob: 7.2.3
+      sax: 1.3.0
+      source-map: 0.7.4
+    transitivePeerDependencies:
+      - supports-color
 
   sucrase@3.35.0:
     dependencies:
@@ -12920,6 +13474,29 @@ snapshots:
     dependencies:
       uuidv7: 0.4.4
 
+  typescript-plugin-css-modules@5.1.0(typescript@5.6.3):
+    dependencies:
+      '@types/postcss-modules-local-by-default': 4.0.2
+      '@types/postcss-modules-scope': 3.0.4
+      dotenv: 16.4.5
+      icss-utils: 5.1.0(postcss@8.4.47)
+      less: 4.2.0
+      lodash.camelcase: 4.3.0
+      postcss: 8.4.47
+      postcss-load-config: 3.1.4(postcss@8.4.47)
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.47)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.47)
+      postcss-modules-scope: 3.2.0(postcss@8.4.47)
+      reserved-words: 0.1.2
+      sass: 1.80.5
+      source-map-js: 1.2.1
+      stylus: 0.62.0
+      tsconfig-paths: 4.2.0
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+
   typescript@5.6.3: {}
 
   unbox-primitive@1.0.2:
@@ -13031,12 +13608,12 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-node@2.1.4(@types/node@20.16.14):
+  vite-node@2.1.4(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
-      vite: 5.4.9(@types/node@20.16.14)
+      vite: 5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -13057,7 +13634,19 @@ snapshots:
       '@types/node': 20.16.14
       fsevents: 2.3.3
 
-  vite@5.4.9(@types/node@20.16.14):
+  vite@4.5.5(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0):
+    dependencies:
+      esbuild: 0.18.20
+      postcss: 8.4.47
+      rollup: 3.29.5
+    optionalDependencies:
+      '@types/node': 20.16.14
+      fsevents: 2.3.3
+      less: 4.2.0
+      sass: 1.80.5
+      stylus: 0.62.0
+
+  vite@5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
@@ -13065,11 +13654,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.16.14
       fsevents: 2.3.3
+      less: 4.2.0
+      sass: 1.80.5
+      stylus: 0.62.0
 
-  vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0):
+  vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@23.2.0)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0):
     dependencies:
       '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(vite@5.4.9(@types/node@20.16.14))
+      '@vitest/mocker': 2.1.4(vite@5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/pretty-format': 2.1.4
       '@vitest/runner': 2.1.4
       '@vitest/snapshot': 2.1.4
@@ -13085,8 +13677,8 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.9(@types/node@20.16.14)
-      vite-node: 2.1.4(@types/node@20.16.14)
+      vite: 5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
+      vite-node: 2.1.4(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.16.14
@@ -13104,10 +13696,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1):
+  vitest@2.1.4(@types/node@20.16.14)(@vitest/ui@2.1.4)(happy-dom@15.7.4)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0):
     dependencies:
       '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(vite@5.4.9(@types/node@20.16.14))
+      '@vitest/mocker': 2.1.4(vite@5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0))
       '@vitest/pretty-format': 2.1.4
       '@vitest/runner': 2.1.4
       '@vitest/snapshot': 2.1.4
@@ -13123,8 +13715,8 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.9(@types/node@20.16.14)
-      vite-node: 2.1.4(@types/node@20.16.14)
+      vite: 5.4.9(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
+      vite-node: 2.1.4(@types/node@20.16.14)(less@4.2.0)(sass@1.80.5)(stylus@0.62.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.16.14
@@ -13279,6 +13871,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@1.10.2: {}
 
   yaml@2.5.1: {}
 


### PR DESCRIPTION
# Context

It's useful to see what a page's SEO will look like before it's been published.

# Overview

This PR adds an SEO Preview pane to Pages, and to the Config SEO settings.

It shows what your fallback SEO and your per-page SEO will look like on Google, Facebook and Twitter.

<img width="817" alt="image" src="https://github.com/user-attachments/assets/1aa5a3e7-0908-4a94-936a-41e52ee07a0a">


## Notes

Future extensions may include:
- More SEO and social previews
- Config to turn on/off social previews for certain platforms

Dark mode isn't supported. It may be nice to support this