### PR TITLE
feat(announcements): add announcements document and structure

### DIFF
--- a/apps/sanity/schema/types/documents.ts
+++ b/apps/sanity/schema/types/documents.ts
@@ -3,8 +3,10 @@ import { page } from './documents/page';
 import { redirects } from '@pkg/sanity-toolkit/redirects/schema';
 import { DOCUMENT } from '@pkg/common/constants/schemaTypes';
 import { INTERNAL_LINK_TYPES } from '@/config/schema';
+import { announcements } from '@/schema/types/documents/announcements';
 
 export const documents: SchemaTypeDefinition[] = [
   page,
+  announcements,
   redirects({ schemaName: DOCUMENT.CONFIG_REDIRECT, internalLinkTypes: INTERNAL_LINK_TYPES }),
 ];

--- a/apps/sanity/schema/types/documents/announcements.ts
+++ b/apps/sanity/schema/types/documents/announcements.ts
@@ -1,0 +1,84 @@
+import { HiSpeakerphone } from 'react-icons/hi';
+import { defineField, defineType } from 'sanity';
+import { validPostTimestamps } from '@pkg/sanity-toolkit/studio/schema/validation';
+
+interface Prepare {
+  title?: string;
+  isActive?: boolean;
+  startDate?: string;
+  endDate?: string;
+}
+
+export const announcements = defineType({
+  name: 'announcement',
+  title: 'Announcement Bar',
+  type: 'document',
+  icon: HiSpeakerphone,
+  fields: [
+    defineField({
+      name: 'message',
+      title: 'Announcement Message',
+      type: 'string',
+      validation: (Rule) =>
+        Rule.required()
+          .max(160)
+          .warning(
+            'Announcements work best when they are concise—consider reduced the length of the announcement message.',
+          ),
+    }),
+    defineField({
+      name: 'startDate',
+      title: 'Start Date & Time',
+      type: 'datetime',
+      description: 'When should this announcement start showing?',
+      options: {
+        timeFormat: 'HH:mm',
+      },
+    }),
+    defineField({
+      name: 'endDate',
+      title: 'End Date & Time',
+      type: 'datetime',
+      description: 'When should this announcement stop showing?',
+      options: {
+        timeFormat: 'HH:mm',
+      },
+      validation: (rule) =>
+        rule
+          .custom(
+            validPostTimestamps('startDate', 'before', undefined, 'Start Date', 'End Date'),
+          )
+          .error(),
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'message',
+      isActive: 'isActive',
+      startDate: 'startDate',
+      endDate: 'endDate',
+    },
+    prepare({ title, isActive, startDate, endDate }: Prepare) {
+      const status = isActive ? '🟢 Active' : '⚫ Inactive';
+      const dateRange = formatDateRange(startDate, endDate);
+
+      return {
+        title: title ?? '[No message set]',
+        subtitle: `${status}${dateRange ? ` • ${dateRange}` : ''}`,
+      };
+    },
+  },
+});
+
+function formatDateRange(startDate?: string, endDate?: string): string {
+  if (!startDate && !endDate) return '';
+
+  const formatDate = (date: string) => new Date(date).toLocaleDateString();
+
+  const parts = [
+    startDate && `Starts: ${formatDate(startDate)}`,
+    endDate && `Ends: ${formatDate(endDate)}`,
+  ].filter(Boolean);
+
+  return parts.join(' • ');
+}

--- a/apps/sanity/structure/index.ts
+++ b/apps/sanity/structure/index.ts
@@ -148,7 +148,22 @@ export const structure: StructureResolver = (S, ctx) => {
       //   title: '404 Not Found',
       //   schemaType: SINGLETON.CONFIG_404,
       // }),
-      placeholder(S, 'Announcement Bar', PiMegaphone),
+      S.listItem()
+        .title('Announcement Bar')
+        .icon(PiMegaphone)
+        .child(
+          S.list()
+            .title('Announcement Bar')
+            .items([
+              S.documentTypeListItem(DOCUMENT.ANNOUNCEMENT).title('Announcements'),
+              // S.divider(),
+              // singletonListItem(S, context, {
+              // title: 'Site Config: Active Theme',
+              // viewTitle: 'Active Theme',
+              // schemaType: SINGLETON.THEME,
+              // }),
+            ]),
+        ),
 
       placeholder(S, 'Navigation Menus', GiHamburgerMenu),
       // S.listItem()


### PR DESCRIPTION
# Context

Announcements are shown at the top of websites in the announcement bar. See this issue for more info https://github.com/hex-digital/lucidity-next-sanity-starter/issues/13

# Overview

This PR implements announcements, to later be used in the active theme announcement bar.

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/3612a2c0-4a68-4bc0-9db2-9922d4f2696f">

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/768de075-52a3-4600-8a0d-f3b3e917f3c7">

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/7a91d797-acfc-4c63-8b49-a24638656609">


Closes #13