### PR TITLE
feat(active-theme): add active theme and bring in announcements

### DIFF
--- a/apps/sanity/schema/types/singletons.ts
+++ b/apps/sanity/schema/types/singletons.ts
@@ -3,8 +3,10 @@ import { recyclingBinDocument } from '@pkg/sanity-toolkit/recycling-bin/schema';
 import { SINGLETON } from '@pkg/common/constants/schemaTypes';
 import { appConfig } from '@/config/app';
 import { configSeo } from '@/schema/types/singletons/configSeo';
+import { theme } from '@/schema/types/singletons/theme';
 
 export const singletons: SchemaTypeDefinition[] = [
   configSeo,
+  theme,
   recyclingBinDocument(SINGLETON.RECYCLING_BIN, { apiVersion: appConfig.apiVersion }),
 ];

--- a/apps/sanity/schema/types/singletons/theme.ts
+++ b/apps/sanity/schema/types/singletons/theme.ts
@@ -1,0 +1,49 @@
+import { defineField, defineType } from 'sanity';
+import { LuSettings2 } from 'react-icons/lu';
+import { DOCUMENT, SINGLETON } from '@pkg/common/constants/schemaTypes';
+
+export const theme = defineType({
+  name: SINGLETON.THEME,
+  title: 'Theme',
+  type: 'document',
+  icon: LuSettings2,
+  fields: [
+    defineField({
+      title: 'Title',
+      name: 'title',
+      type: 'string',
+      hidden: true,
+      initialValue: 'Active Theme',
+    }),
+    defineField({
+      title: 'Active Announcements',
+      name: 'activeAnnouncements',
+      description:
+        'Select the announcements to display at the top of all pages. Remove all to show no announcements. Announcements outside their start and end dates will not be shown.',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: { type: DOCUMENT.ANNOUNCEMENT },
+        },
+      ],
+    }),
+    // @todo add active header and footer nav
+    // defineField({
+    //   title: 'Main navigation',
+    //   name: 'mainNavigation',
+    //   description: 'Select main navigation',
+    //   type: 'reference',
+    //   to: { type: DOCUMENT.NAVIGATION_HEADER },
+    //   validation: (rule) => rule.required(),
+    // }),
+    // defineField({
+    //   title: 'Footer navigation',
+    //   name: 'mainFooter',
+    //   description: 'Select menu for main footer navigation',
+    //   type: 'reference',
+    //   to: { type: DOCUMENT.NAVIGATION_FOOTER },
+    //   validation: (rule) => rule.required(),
+    // }),
+  ],
+});

--- a/apps/sanity/structure/index.ts
+++ b/apps/sanity/structure/index.ts
@@ -156,12 +156,12 @@ export const structure: StructureResolver = (S, ctx) => {
             .title('Announcement Bar')
             .items([
               S.documentTypeListItem(DOCUMENT.ANNOUNCEMENT).title('Announcements'),
-              // S.divider(),
-              // singletonListItem(S, context, {
-              // title: 'Site Config: Active Theme',
-              // viewTitle: 'Active Theme',
-              // schemaType: SINGLETON.THEME,
-              // }),
+              S.divider(),
+              singletonListItem(S, context, {
+                title: 'Site Config: Active Theme',
+                viewTitle: 'Active Theme',
+                schemaType: SINGLETON.THEME,
+              }),
             ]),
         ),
 


### PR DESCRIPTION
# Context

The "Active Theme" is used for setting currently active settings, like navigation menus, footer, and the announcement bar.

# Overview

This PR adds the Active Theme singleton. It sets up the document to take a series of Announcement Bars, and some draft code for use later on when we have headers and footers.

It's added to the Site Config, and as an in-place menu item wherever other options are (i.e. next to the announcements)

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/4f7942fb-d257-4dfb-8596-2ef2de0bb518">
