### PR TITLE
feat(article-document): add a default article document, with generated publish date and reading time

### DIFF
--- a/apps/sanity/actions/index.ts
+++ b/apps/sanity/actions/index.ts
@@ -3,6 +3,10 @@ import {
   modifyAction,
 } from '@pkg/sanity-toolkit/studio/actions/resolver';
 import { changePublishText } from '@pkg/sanity-toolkit/studio/actions/changePublishText';
+import { DOCUMENT } from '@pkg/common/constants/schemaTypes';
+import { setDateFieldToCurrent } from '@pkg/sanity-toolkit/studio/actions/setDateFieldToCurrent';
+import { setReadingTime } from '@pkg/sanity-toolkit/studio/actions/setReadingTime';
+import { getArticleContentLength } from '@/features/generic/utilities/getArticleContentLength';
 
 // See: https://www.sanity.io/docs/document-actions
 
@@ -11,5 +15,15 @@ export const documentActions = resolveActionsPipeline([
   modifyAction({
     actions: ['publish'],
     handler: (action) => changePublishText(action, 'Update'), // Use "Update" if document already published
+  }),
+  modifyAction({
+    actions: ['publish'],
+    schemaTypes: [DOCUMENT.ARTICLE],
+    handler: (action) => setDateFieldToCurrent(action),
+  }),
+  modifyAction({
+    actions: ['publish'],
+    schemaTypes: [DOCUMENT.ARTICLE],
+    handler: (action) => setReadingTime(action, getArticleContentLength), // Use "Update" if document already published
   }),
 ]);

--- a/apps/sanity/features/generic/utilities/getArticleContentLength.ts
+++ b/apps/sanity/features/generic/utilities/getArticleContentLength.ts
@@ -1,0 +1,34 @@
+import type { SanityDocument } from 'sanity';
+import { ModularBlock } from '@/features/modular-content-blocks/config/defaultBlockGroups';
+import { OBJECT } from '@pkg/common/constants/schemaTypes';
+import { toPlainText } from '@portabletext/toolkit';
+
+export function getArticleContentLength(draft: SanityDocument | null) {
+  if (!draft) {
+    return 0;
+  }
+
+  const content = draft.content as Array<ModularBlock & { content?: Array<ModularBlock> }>;
+
+  return content.reduce<number>((acc, block) => {
+    // An outer block with no inner blocks
+    if (!block.content) {
+      return acc;
+    }
+
+    // An outer block that has inner blocks
+    const innerBlocksLength = block.content.reduce<number>((innerAcc, block) => {
+      let contentLength = 0;
+
+      if (block._type === OBJECT.MODULAR_INNER_BLOCK_RAW_HTML) {
+        // @todo generate types for the blocks and use them here
+        // @ts-expect-error block.content is of type unknown
+        contentLength = toPlainText(block.content?.code).length;
+      }
+
+      return innerAcc + contentLength;
+    }, 0);
+
+    return acc + innerBlocksLength;
+  }, 0);
+}

--- a/apps/sanity/package.json
+++ b/apps/sanity/package.json
@@ -35,6 +35,7 @@
     "@pkg/modular-content-blocks": "workspace:*",
     "@pkg/sanity-toolkit": "workspace:*",
     "@pkg/utilities": "workspace:*",
+    "@portabletext/toolkit": "^2.0.16",
     "@sanity/code-input": "4.1.4",
     "@sanity/icons": "3.4.0",
     "@sanity/image-url": "^1.1.0",

--- a/apps/sanity/schema/types/documents.ts
+++ b/apps/sanity/schema/types/documents.ts
@@ -4,9 +4,11 @@ import { redirects } from '@pkg/sanity-toolkit/redirects/schema';
 import { DOCUMENT } from '@pkg/common/constants/schemaTypes';
 import { INTERNAL_LINK_TYPES } from '@/config/schema';
 import { announcements } from '@/schema/types/documents/announcements';
+import { article } from '@/schema/types/documents/article';
 
 export const documents: SchemaTypeDefinition[] = [
   page,
+  article,
   announcements,
   redirects({ schemaName: DOCUMENT.CONFIG_REDIRECT, internalLinkTypes: INTERNAL_LINK_TYPES }),
 ];

--- a/apps/sanity/schema/types/documents/article.ts
+++ b/apps/sanity/schema/types/documents/article.ts
@@ -1,0 +1,173 @@
+import { defineField, defineType } from 'sanity';
+import { PiFilesLight } from 'react-icons/pi';
+import { DOCUMENT, OBJECT } from '@pkg/common/constants/schemaTypes';
+import {
+  defineVisibilityField,
+  visibilityPreview,
+} from '@pkg/sanity-toolkit/seo/schema/defineVisibilityField';
+import { defineInternalTitleField } from '@pkg/sanity-toolkit/studio/schema/fields/defineInternalTitleField';
+import { PAGE_VISIBILITY, SEO_FIELDSET } from '@pkg/sanity-toolkit/seo/constants';
+import { withFieldset, withGroup } from '@pkg/sanity-toolkit/studio/schema/utilities';
+import { seoFieldset } from '@pkg/sanity-toolkit/seo/schema/seoFieldset';
+import {
+  FIELD_GROUPS,
+  GROUP_CONTENT,
+  GROUP_META,
+  GROUP_SEO,
+} from '@pkg/sanity-toolkit/studio/constants/fieldGroups';
+import { orderByPathname, orderByTitle } from '@pkg/sanity-toolkit/studio/schema/orderings';
+import { definePathnameField } from '@/features/generic/schema/definePathnameField';
+import { defineSeoFields } from '@/features/seo/schema/defineSeoFields';
+import { GrArticle } from 'react-icons/gr';
+import { URL_PREFIX } from '@pkg/common/constants/urlPrefixes';
+import { validPostTimestamps } from '@pkg/sanity-toolkit/studio/schema/validation';
+import { isDeveloperOrAdmin } from '@pkg/sanity-toolkit/studio/utilities/roles';
+import { defineImageField } from '@pkg/sanity-toolkit/studio/schema/fields/defineImageField';
+
+interface Prepare {
+  title?: string;
+  pathname?: string;
+  visibility?: PAGE_VISIBILITY;
+  image?: any;
+}
+
+export const article = defineType({
+  name: DOCUMENT.ARTICLE,
+  title: 'Article',
+  type: 'document',
+  icon: GrArticle,
+
+  groups: [GROUP_META, { ...GROUP_CONTENT, default: true }, GROUP_SEO],
+
+  fieldsets: [seoFieldset()],
+
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      description: 'The title of the article. Shown in the article header and in lists',
+      group: [FIELD_GROUPS.META, FIELD_GROUPS.CONTENT],
+      validation: (rule) => rule.required(),
+    }),
+
+    ...withGroup(FIELD_GROUPS.META, [
+      defineVisibilityField(),
+      definePathnameField({
+        initialValue: { current: `${URL_PREFIX.ARTICLES}/` },
+        options: { source: 'title', folder: { canUnlock: false } },
+      }),
+
+      defineField({
+        title: 'Published At',
+        name: 'publishedAt',
+        type: 'datetime',
+        description:
+          'The date this article was published. If blank, will be set automatically when article is published. May show on the article itself, in the sitemap, or in any RSS feeds',
+        validation: (rule) =>
+          rule
+            .custom(
+              validPostTimestamps(
+                'updatedAt',
+                'after',
+                undefined,
+                'Published At',
+                'Updated At',
+              ),
+            )
+            .error(),
+      }),
+      defineField({
+        title: 'Updated At',
+        name: 'updatedAt',
+        type: 'datetime',
+        group: 'meta',
+        description:
+          'Optional. Manually specify the date this article was updated. Will NOT be updated automatically. May show on the article itself, in the sitemap, or in any RSS feeds',
+        validation: (rule) =>
+          rule
+            .custom(
+              validPostTimestamps(
+                'publishedAt',
+                'before',
+                undefined,
+                'Updated At',
+                'Published At',
+              ),
+            )
+            .error(),
+      }),
+      defineField({
+        title: 'Reading time',
+        name: 'readingTime',
+        type: 'string',
+        description:
+          "The reading time of the article's content. Set automatically when article is published or updated",
+        readOnly: true,
+        hidden: ({ currentUser }) => !isDeveloperOrAdmin(currentUser),
+        initialValue: 'Less than 1',
+      }),
+      defineField({
+        ...defineImageField(),
+        title: 'Article Image',
+        name: 'image',
+        description:
+          'This image is displayed on the article and in any list where the article appears',
+        validation: (rule) =>
+          rule
+            .required()
+            .warning(
+              'An image is recommend. Images make search results look more inviting and engaging',
+            ),
+      }),
+    ]),
+
+    ...withGroup(FIELD_GROUPS.CONTENT, [
+      defineField({
+        title: 'Excerpt',
+        name: 'excerpt',
+        type: 'text',
+        rows: 5,
+        description:
+          'A brief description or excerpt that is displayed in some lists where the article appears',
+        validation: (rule) =>
+          rule
+            .required()
+            .warning(
+              'An excerpt is recommend. Excerpts make it easier for users to find what they are looking for',
+            ),
+      }),
+      defineField({
+        name: 'content',
+        title: 'Modular Content',
+        type: OBJECT.MODULAR_OUTER_BLOCKS,
+      }),
+    ]),
+
+    ...withGroup(FIELD_GROUPS.SEO, [...withFieldset(SEO_FIELDSET, [...defineSeoFields()])]),
+  ],
+  orderings: [orderByPathname(), orderByTitle()],
+  preview: {
+    select: {
+      title: 'title',
+      pathname: 'pathname.current',
+      visibility: 'pageVisibility',
+      image: 'image',
+    },
+    prepare({ title, pathname, visibility, image }: Partial<Prepare>) {
+      const subtitle: Array<string> = [visibilityPreview(visibility)];
+
+      console.log('image', image);
+
+      if (pathname) {
+        subtitle.push(pathname);
+      }
+
+      return {
+        title: title ?? 'Unnamed',
+        subtitle: subtitle.join(' - '),
+        media: image,
+      };
+    },
+  },
+});

--- a/apps/sanity/structure/index.ts
+++ b/apps/sanity/structure/index.ts
@@ -77,20 +77,19 @@ export const structure: StructureResolver = (S, ctx) => {
         ),
       S.divider(),
 
-      placeholder(S, 'Articles', GrArticle),
-      // S.listItem()
-      //   .title('Articles')
-      //   .icon(GrArticle)
-      //   .child(
-      //     S.list()
-      //       .title('Articles')
-      //       .items(
-      //         publishStatusListItems(S, context, {
-      //           schemaType: DOCUMENT.ARTICLE,
-      //           title: 'Articles',
-      //         }),
-      //       ),
-      //   ),
+      S.listItem()
+        .title('Articles')
+        .icon(GrArticle)
+        .child(
+          S.list()
+            .title('Articles')
+            .items(
+              publishStatusListItems(S, context, {
+                schemaType: DOCUMENT.ARTICLE,
+                title: 'Articles',
+              }),
+            ),
+        ),
       S.divider(),
 
       placeholder(S, 'Authors', FaUserPen),

--- a/packages/common/constants/urlPrefixes.ts
+++ b/packages/common/constants/urlPrefixes.ts
@@ -1,0 +1,8 @@
+/**
+ * The URL prefixes added to certain documents.
+ * Changing these will not change any document pathnames that store this prefix in their pathname
+ * field—a migration is also needed to update these.
+ */
+export enum URL_PREFIX {
+  ARTICLES = '/articles',
+}

--- a/packages/sanity-toolkit/package.json
+++ b/packages/sanity-toolkit/package.json
@@ -35,6 +35,7 @@
     "vitest": "^2.1.4"
   },
   "peerDependencies": {
+    "@portabletext/toolkit": "^2.0.16",
     "@sanity/icons": "^3.4.0",
     "@sanity/image-url": "^1.0.2",
     "@sanity/types": "^3.61.0",
@@ -48,7 +49,6 @@
     "styled-components": "^6.1.13"
   },
   "dependencies": {
-    "@portabletext/toolkit": "^2.0.16",
     "nanoid": "^5.0.8",
     "prettier": "^3.3.3"
   },

--- a/packages/sanity-toolkit/studio/actions/__tests__/publishedAndUpdateDate.test.ts
+++ b/packages/sanity-toolkit/studio/actions/__tests__/publishedAndUpdateDate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { publishAndUpdateDate } from '../publishAndUpdateDate';
+import { setDateFieldToCurrent } from '../setDateFieldToCurrent';
 import { useDocumentOperation } from 'sanity';
 
 vi.mock('sanity', () => ({
@@ -38,7 +38,7 @@ describe('publishAndUpdateDate', () => {
       onHandle: vi.fn(),
     });
 
-    const PublishAndUpdateDate = publishAndUpdateDate(originalPublishAction);
+    const PublishAndUpdateDate = setDateFieldToCurrent(originalPublishAction);
 
     const result = PublishAndUpdateDate(mockProps);
     if (result?.onHandle) {
@@ -72,7 +72,7 @@ describe('publishAndUpdateDate', () => {
       onHandle: vi.fn(),
     });
 
-    const PublishAndUpdateDate = publishAndUpdateDate(originalPublishAction);
+    const PublishAndUpdateDate = setDateFieldToCurrent(originalPublishAction);
 
     const result = PublishAndUpdateDate(props);
     if (result?.onHandle) {

--- a/packages/sanity-toolkit/studio/actions/setDateFieldToCurrent.ts
+++ b/packages/sanity-toolkit/studio/actions/setDateFieldToCurrent.ts
@@ -3,11 +3,14 @@ import { type DocumentActionComponent, useDocumentOperation } from 'sanity';
 /**
  * Set a field with the current date when a document is published.
  * If the field already has a value, it will not be overridden.
- * Defaults to the `publishedAt` field. Specify the fieldname in the second parameter.
+ * Defaults to the `publishedAt` field.
+ * Specify the field name to set in the second parameter.
+ * Set force to true to update the field value even if it already has a value.
  */
-export function publishAndUpdateDate(
+export function setDateFieldToCurrent(
   originalPublishAction: DocumentActionComponent,
   fieldName = 'publishedAt',
+  force = false,
 ) {
   const PublishAndUpdateDate: DocumentActionComponent = (props) => {
     const originalResult = originalPublishAction(props);
@@ -22,7 +25,7 @@ export function publishAndUpdateDate(
       ...originalResult,
 
       onHandle: () => {
-        if (!props.draft?.[fieldName]) {
+        if (force || !props.draft?.[fieldName]) {
           patch.execute([{ set: { [fieldName]: new Date().toISOString() } }]);
         }
 

--- a/packages/sanity-toolkit/studio/actions/setReadingTime.ts
+++ b/packages/sanity-toolkit/studio/actions/setReadingTime.ts
@@ -1,0 +1,52 @@
+import {
+  type DocumentActionComponent,
+  type SanityDocument,
+  useDocumentOperation,
+} from 'sanity';
+import { readingTime } from '../utilities/readingTime';
+
+/**
+ * Sets a field to the total reading time it will take to read the content.
+ * Defaults to the `readingTime` field.
+ * Specify the function to calculate the total reading time in the second parameter.
+ * Specify the field name to set in the third parameter.
+ * Setting force to false will only update the field value if it is empty.
+ */
+export function setReadingTime(
+  originalPublishAction: DocumentActionComponent,
+  contentLengthFn: (draft: SanityDocument | null) => number,
+  fieldName = 'readingTime',
+  force = true,
+) {
+  const PublishAndUpdateDate: DocumentActionComponent = (props) => {
+    const originalResult = originalPublishAction(props);
+
+    const { patch } = useDocumentOperation(props.id, props.type);
+
+    if (!originalResult) {
+      return originalResult;
+    }
+
+    return {
+      ...originalResult,
+
+      onHandle: () => {
+        const articleLength = props.draft?.content ? contentLengthFn(props.draft) : 0;
+
+        if (force || !props.draft?.[fieldName]) {
+          patch.execute([
+            {
+              set: { [fieldName]: readingTime(articleLength).estimatedReadingTime },
+            },
+          ]);
+        }
+
+        if (originalResult?.onHandle) {
+          originalResult.onHandle();
+        }
+      },
+    };
+  };
+
+  return PublishAndUpdateDate;
+}

--- a/packages/sanity-toolkit/studio/utilities/readingTime.ts
+++ b/packages/sanity-toolkit/studio/utilities/readingTime.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns a number in minutes for estimated reading time.
+ * By default, we assume an average word length of 5 characters, and an average
+ * words per minute of 180. These are configurable via the options.
+ */
+export function readingTime(
+  contentLength: number,
+  options?: {
+    averageWordLength?: number;
+    averageWordsPerMinute?: number;
+  },
+) {
+  const averageWordLength = options?.averageWordLength ?? 5;
+  const averageWordsPerMinute = options?.averageWordsPerMinute ?? 180;
+
+  const readTime = Math.round(contentLength / averageWordLength / averageWordsPerMinute);
+
+  const estimatedReadingTime = readTime === 0 ? 'Less than 1' : `${readTime}`;
+
+  return {
+    estimatedReadingTime,
+    readingTimeText: estimatedReadingTime ? `${estimatedReadingTime} minute read` : null,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@pkg/utilities':
         specifier: workspace:*
         version: link:../../packages/utilities
+      '@portabletext/toolkit':
+        specifier: ^2.0.16
+        version: 2.0.16
       '@sanity/code-input':
         specifier: 4.1.4
         version: 4.1.4(@babel/runtime@7.26.0)(@codemirror/lint@6.8.2)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.2.3)(codemirror@6.0.1(@lezer/common@1.2.3))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@3.63.0(@types/node@22.9.0)(@types/react@18.3.12)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.6)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(stylus@0.62.0))(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -9559,7 +9562,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@22.9.0)(@vitest/ui@2.1.4)(happy-dom@15.11.0)(jsdom@25.0.1)(less@4.2.0)(sass@1.80.6)(stylus@0.62.0)
+      vitest: 2.1.4(@types/node@22.9.0)(@vitest/ui@2.1.4)(happy-dom@15.11.0)(jsdom@23.2.0)(less@4.2.0)(sass@1.80.6)(stylus@0.62.0)
 
   '@vitest/utils@2.1.4':
     dependencies:


### PR DESCRIPTION
# Context

We want to provide an Article schema out of the box for use with a blog.

It should serve all articles under `/articles` by default, and this should be configurable.

It should also set a publish date automatically when published (if not set manually), as well as a reading time in minutes that should be updated each time the document is published or updated.

It should also have sane default fields, such as an updated date, an excerpt, and an image.

Lastly, it should be integrated with our SEO fields, our visibility, our Sanity structure, and later on any other tools like Sitemap or RSS feed.

# Overview

This PR adds the Article schema.

The Article has the following fields;

- Title
- Page Visibility
- Pathname
- Published At
- Updated At
- Reading Time
- Article Image
- Excerpt
- Content
- SEO

This PR also adds two new actions: `setDateFieldToCurrent` and `setReadingTime`. It adds these actions to the Article schemaType. These actions automatically set the `publishedAt` value of an article if it's empty, and updates the `readingTime` field, on publish.

Lastly, the article schema has been added to the sanity structure. It utilises the `publishStatusListItems` helper to show the following structure:

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/0113e4bd-1b51-4213-9e59-7f161dcc0f66">
