### PR TITLE
feat: add CMS redirects middleware

### DIFF
--- a/apps/web/config/redirects.ts
+++ b/apps/web/config/redirects.ts
@@ -1,0 +1,16 @@
+import { skipFileExtensions } from '@pkg/sanity-toolkit/redirects/config';
+
+export type RedirectsConfig = typeof redirectsConfig;
+
+export const redirectsConfig = {
+  /** The path to the redirects API endpoint that retrieves the redirects from the CMS (as cannot cache this request in a Next middleware). */
+  apiPath: '/api/redirects/cms',
+
+  /** Do not process the redirects middleware for all paths that start with any of these prefixes. */
+  skipPathPrefixes: ['/api'],
+
+  /**
+   * The file extensions that should not be processed by the redirects middleware.
+   */
+  skipFileExtensions: [...skipFileExtensions],
+};

--- a/apps/web/src/app/api/(routes)/redirects/cms/route.ts
+++ b/apps/web/src/app/api/(routes)/redirects/cms/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { type RedirectsQueryPayload } from '@pkg/sanity-toolkit/redirects/types';
+import { REDIRECTS_QUERY } from '@pkg/sanity-toolkit/redirects/queries';
+import { DOCUMENT } from '@pkg/common/constants/schemaTypes';
+import { loadQuery } from '@/features/sanity/data/loadQuery.server';
+
+export async function GET() {
+  const cmsRedirects = await loadQuery<RedirectsQueryPayload | null>(
+    REDIRECTS_QUERY(DOCUMENT.CONFIG_REDIRECT),
+    {},
+    {
+      useCdn: true,
+      cache: 'force-cache',
+      next: {
+        tags: [DOCUMENT.CONFIG_REDIRECT],
+      },
+    },
+  );
+
+  return NextResponse.json(cmsRedirects.data ?? {});
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,10 +1,11 @@
 import type { NextRequest } from 'next/server';
 import { runNextMiddlewarePipeline } from '@pkg/next-middleware/utilities';
-import madeWithLucidity from './middleware/made-with-lucidity';
-import middlewareProcessed from './middleware/middleware-processed';
+import { madeWithLucidity } from './middleware/made-with-lucidity';
+import { middlewareProcessed } from './middleware/middleware-processed';
+import { cmsRedirects } from './middleware/cmsRedirects';
 
 /** Add middleware to the pipeline here. They will be executed in the order they are listed here. */
-const middlewarePipeline = [middlewareProcessed, madeWithLucidity];
+const middlewarePipeline = [cmsRedirects, middlewareProcessed, madeWithLucidity];
 
 /** See: https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher */
 export const config = {

--- a/apps/web/src/middleware/cmsRedirects.ts
+++ b/apps/web/src/middleware/cmsRedirects.ts
@@ -1,0 +1,51 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { defineNextMiddleware, fetchJson } from '@pkg/next-middleware/utilities';
+import { redirectResolver } from '@pkg/sanity-toolkit/redirects';
+import { type RedirectsQueryPayload } from '@pkg/sanity-toolkit/redirects/types';
+
+/** Do not process the redirects middleware for all paths that start with any of these prefixes */
+const skipPathPrefixes = ['/api'];
+/** The path to the redirects API endpoint that retrieves the redirects from the CMS (as cannot cache this request in a Next middleware) */
+const redirectsApiPath = '/api/redirects/cms';
+
+export const cmsRedirects = defineNextMiddleware(async (request, response) => {
+  const path = request.nextUrl.pathname;
+  const query = request.nextUrl.searchParams;
+
+  if (skipPathPrefixes.some((prefix) => path.startsWith(prefix))) {
+    return response;
+  }
+
+  try {
+    const redirect = await redirectResolver(path, query, getCmsRedirects(request));
+
+    if (redirect) {
+      return NextResponse.redirect(new URL(redirect.path, request.url), {
+        status: redirect.code,
+        headers: {
+          'X-Redirected-From': request.nextUrl.toString(),
+          'X-Redirected-By': 'Next CMS Redirects Middleware',
+          'X-Redirects-Retrieved': redirect.retrievedOn,
+        },
+      });
+    }
+  } catch (error) {
+    console.error('Unable to resolve CMS redirects. Skipping CMS redirects middleware', error);
+  }
+});
+
+function getCmsRedirects(request: NextRequest) {
+  return async function getCmsRedirectsFn() {
+    const redirects = await fetchJson<RedirectsQueryPayload | null>(
+      new URL(redirectsApiPath, request.nextUrl.origin),
+    );
+
+    return (
+      redirects ?? {
+        redirects: [],
+        retrievedOn: new Date().toISOString(),
+      }
+    );
+  };
+}

--- a/apps/web/src/middleware/made-with-lucidity.ts
+++ b/apps/web/src/middleware/made-with-lucidity.ts
@@ -1,6 +1,6 @@
 import { defineNextMiddleware } from '@pkg/next-middleware/utilities';
 
-export default defineNextMiddleware((_request, response) => {
+export const madeWithLucidity = defineNextMiddleware((_request, response) => {
   response.headers.set(
     'X-Made-With',
     'https://github.com/hex-digital/lucidity-next-sanity-starter',

--- a/apps/web/src/middleware/middleware-processed.ts
+++ b/apps/web/src/middleware/middleware-processed.ts
@@ -1,6 +1,6 @@
 import { defineNextMiddleware } from '@pkg/next-middleware/utilities';
 
-export default defineNextMiddleware((_request, response) => {
+export const middlewareProcessed = defineNextMiddleware((_request, response) => {
   response.headers.set('X-Middleware-Processed', 'true');
 
   return response;

--- a/packages/sanity-toolkit/redirects/config.ts
+++ b/packages/sanity-toolkit/redirects/config.ts
@@ -1,0 +1,15 @@
+export const skipFileExtensions = [
+  'index.xml',
+  'sitemap.xml',
+  'style.xsl',
+  '.css',
+  '.png',
+  '.svg',
+  '.jpg',
+  '.webp',
+  '.aiff',
+  '.woff',
+  '.woff2',
+  '.mp3',
+  '.mp4',
+];

--- a/packages/sanity-toolkit/redirects/constants/index.ts
+++ b/packages/sanity-toolkit/redirects/constants/index.ts
@@ -2,3 +2,6 @@ export enum REDIRECT_TYPE {
   DIRECT_PAGE = 'directPage',
   LINK = 'link',
 }
+
+export const PERMANENT_REDIRECT_CODE = 308;
+export const TEMPORARY_REDIRECT_CODE = 307;

--- a/packages/sanity-toolkit/redirects/index.ts
+++ b/packages/sanity-toolkit/redirects/index.ts
@@ -1,0 +1,77 @@
+import { REDIRECT_TYPE, PERMANENT_REDIRECT_CODE, TEMPORARY_REDIRECT_CODE } from './constants';
+import type { Redirect, RedirectMatchResult, RedirectsQueryPayload } from './types';
+import { skipFileExtensions } from './config';
+import { combinePathAndQuery, constructRedirectUrl, patternToRegex } from './utilities';
+
+export async function redirectResolver(
+  path: string,
+  query: URLSearchParams | undefined,
+  cmsRedirectsResolver: () => RedirectsQueryPayload | Promise<RedirectsQueryPayload>,
+  incrementRedirectRuleCount?: (rule: Redirect) => void,
+) {
+  if (skipFileExtensions.some((skipExtension) => path.endsWith(skipExtension))) {
+    return;
+  }
+
+  const { redirects, retrievedOn } = await cmsRedirectsResolver();
+
+  const { matches, matchedRule, redirectUrl } = matchPathWithRules(path, redirects);
+
+  if (matches && matchedRule && redirectUrl) {
+    if (incrementRedirectRuleCount) {
+      incrementRedirectRuleCount(matchedRule); // We don't await this as we don't care if it happens or not, and don't want to delay page load
+    }
+
+    const finalPath = combinePathAndQuery(redirectUrl, query);
+
+    const code = matchedRule.isPermanent ? PERMANENT_REDIRECT_CODE : TEMPORARY_REDIRECT_CODE;
+
+    return { path: finalPath, code, retrievedOn };
+  }
+
+  return undefined;
+}
+
+function matchPathWithRules(path: string, redirects: Array<Redirect>): RedirectMatchResult {
+  const notFound = { matches: false };
+
+  for (const rule of redirects) {
+    try {
+      const pattern = rule.from;
+      const redirectUrl =
+        rule.link?.linkType === REDIRECT_TYPE.DIRECT_PAGE
+          ? rule.link?.page?.pathname
+          : rule.link?.external;
+
+      if (!redirectUrl || !pattern) {
+        return notFound;
+      }
+
+      const regex = patternToRegex(pattern);
+      const match = path.match(regex);
+
+      if (match) {
+        return {
+          matches: true,
+          matchedRule: rule,
+          redirectUrl: constructRedirectUrl(match, redirectUrl),
+        };
+      }
+    } catch (error) {
+      // Just continue if any errors, we will just ignore them as no need to hold up loading the page for this
+      console.log(error);
+      // @todo re-add when Sentry is added
+      // @todo move this to a error handler that is passed in as config
+      // withScope(function (scope) {
+      //   scope.setTag('section', 'redirects');
+      //   scope.setContext('redirectData', {
+      //     path,
+      //     redirectRuleId: rule._id,
+      //   });
+      //   captureException(error);
+      // });
+    }
+  }
+
+  return notFound;
+}

--- a/packages/sanity-toolkit/redirects/index.ts
+++ b/packages/sanity-toolkit/redirects/index.ts
@@ -3,13 +3,23 @@ import type { Redirect, RedirectMatchResult, RedirectsQueryPayload } from './typ
 import { skipFileExtensions } from './config';
 import { combinePathAndQuery, constructRedirectUrl, patternToRegex } from './utilities';
 
+interface Options {
+  skipFileExtensions?: Array<string>;
+  incrementRedirectRuleCount?: (rule: Redirect) => void;
+}
+
 export async function redirectResolver(
   path: string,
   query: URLSearchParams | undefined,
   cmsRedirectsResolver: () => RedirectsQueryPayload | Promise<RedirectsQueryPayload>,
-  incrementRedirectRuleCount?: (rule: Redirect) => void,
+  options: Options = {},
 ) {
-  if (skipFileExtensions.some((skipExtension) => path.endsWith(skipExtension))) {
+  const opts = {
+    skipFileExtensions,
+    ...options,
+  };
+
+  if (options.skipFileExtensions?.some((skipExtension) => path.endsWith(skipExtension))) {
     return;
   }
 
@@ -18,8 +28,8 @@ export async function redirectResolver(
   const { matches, matchedRule, redirectUrl } = matchPathWithRules(path, redirects);
 
   if (matches && matchedRule && redirectUrl) {
-    if (incrementRedirectRuleCount) {
-      incrementRedirectRuleCount(matchedRule); // We don't await this as we don't care if it happens or not, and don't want to delay page load
+    if (options.incrementRedirectRuleCount) {
+      options.incrementRedirectRuleCount(matchedRule); // We don't await this as we don't care if it happens or not, and don't want to delay page load
     }
 
     const finalPath = combinePathAndQuery(redirectUrl, query);

--- a/packages/sanity-toolkit/redirects/queries/index.ts
+++ b/packages/sanity-toolkit/redirects/queries/index.ts
@@ -1,0 +1,24 @@
+import { defineQuery } from 'groq';
+
+export function REDIRECTS_QUERY(schemaType: string, pathname?: string) {
+  return defineQuery(`
+    {
+      'redirects': *[_type == "${schemaType}"][] {
+        _id,
+        from,
+        link {
+          linkType,
+          pageAnchor,
+          "page": page->{
+            pageVisibility,
+            'pathname': ${pathname ?? `coalesce(pathname.current, slug.current)`},
+          },
+          external,
+        },
+        isPermanent,
+        group,
+      },
+      'retrievedOn': now(),
+    }
+  `);
+}

--- a/packages/sanity-toolkit/redirects/schema/defineRedirectFields.ts
+++ b/packages/sanity-toolkit/redirects/schema/defineRedirectFields.ts
@@ -52,6 +52,8 @@ export function defineRedirectFields(internalLinkTypes: Array<string>) {
           title: 'Link Type',
           name: 'linkType',
           type: 'string',
+          description:
+            'Use "Page" to choose a page from the CMS. Its URL will be kept up-to-date if it changes. Otherwise use "Link" to enter a full URL.',
           initialValue: REDIRECT_TYPE.DIRECT_PAGE,
           options: {
             layout: 'radio',

--- a/packages/sanity-toolkit/redirects/types/index.ts
+++ b/packages/sanity-toolkit/redirects/types/index.ts
@@ -1,0 +1,47 @@
+import { REDIRECT_TYPE } from '../constants';
+import { PAGE_VISIBILITY } from '../../seo';
+
+export interface RedirectsQueryPayload {
+  redirects: Array<Redirect>;
+  retrievedOn: string;
+}
+
+export interface RedirectMatchResult {
+  matches: boolean;
+  matchedRule?: Redirect;
+  redirectUrl?: string;
+}
+
+export interface RedirectDocument {
+  _rev: string;
+  _type: string;
+  _id: string;
+  _createdAt: string;
+  _updatedAt: string;
+  from?: null | `/${string}`;
+  link?: null | RedirectLink;
+  isPermanent?: null | boolean;
+  group?: null | string;
+}
+
+export interface RedirectLink {
+  linkType?: REDIRECT_TYPE;
+  page?: ReferencedInternal;
+  pageAnchor?: string;
+  external?: string;
+}
+
+export interface ReferencedInternal {
+  _id: string;
+  _type: string;
+  _rev: string;
+  _updatedAt?: string;
+  _originalId?: string;
+  _createdAt?: string;
+  title?: string;
+  pathname?: string;
+  pageVisibility?: PAGE_VISIBILITY;
+}
+
+/** The Redirect object we get back from our query, as we don't ask for all data */
+export type Redirect = Omit<RedirectDocument, '_type' | '_rev' | '_createdAt' | '_updatedAt'>;

--- a/packages/sanity-toolkit/redirects/utilities/incrementRedirectRuleCount.ts
+++ b/packages/sanity-toolkit/redirects/utilities/incrementRedirectRuleCount.ts
@@ -1,0 +1,42 @@
+import type { SanityClient } from 'sanity';
+import type { Redirect } from '../types';
+
+export function incrementRedirectRuleCountFn(client: SanityClient, sanityToken: string) {
+  return function incrementRedirectRuleCount(rule: Redirect) {
+    return;
+
+    /**
+     * Currently disabled as updating the record invalidates the redirects cache - see: https://hexdigital.slack.com/archives/C06BB8DAU7M/p1722859594907949
+     * Instead, we should store the count in a separate record, so the actual redirects don't update.
+     * Then show the count on each redirect using a custom UI component in Sanity.
+     */
+    // const ruleId = rule._id;
+
+    // if (!ruleId) {
+    //   console.error('Count not increment redirect rule count - no rule _id found');
+    //   return;
+    // }
+
+    // client
+    //   .withConfig({ token: sanityToken })
+    //   .patch(ruleId)
+    //   .inc({ count: 1 })
+    //   .commit()
+    //   .catch((err: unknown) => {
+    //     console.error(err);
+    //   });
+
+    // @todo re-add when Sentry is added
+    // @todo move this to a error handler that is passed in as config
+    // .catch((error) => {
+    //   withScope(function (scope) {
+    //     scope.setTag('section', 'redirects');
+    //     scope.setContext('redirectData', {
+    //       message: `Error incrementing redirect rule count with ID ${ruleId}`,
+    //       redirectRuleId: rule._id,
+    //     });
+    //     captureException(error);
+    //   });
+    // });
+  };
+}

--- a/packages/sanity-toolkit/redirects/utilities/index.ts
+++ b/packages/sanity-toolkit/redirects/utilities/index.ts
@@ -1,0 +1,33 @@
+export function combinePathAndQuery(path: string, query?: URLSearchParams) {
+  if (!query || [...query.keys()].length === 0) {
+    return path;
+  }
+
+  const queryString = query.toString();
+
+  const concatCharacter = path.includes('?') ? '+' : '?';
+
+  return `${path}${concatCharacter}${queryString}`;
+}
+
+export function patternToRegex(pattern: string): RegExp {
+  const regexStr =
+    pattern
+      .replace(/\//g, '\\/') // Escape slashes
+      .replace(/\*/g, '.*') // Convert * to .*
+      .replace(/:(\w+)/g, '(?<$1>[^\\/]+)') + // Convert :slug to named capture group
+    '/?'; // Optionally allow trailing slashes
+
+  return new RegExp(`^${regexStr}$`);
+}
+
+export function constructRedirectUrl(match: RegExpMatchArray, redirectUrl: string): string {
+  let constructedUrl = redirectUrl;
+
+  // Replace named capture groups in redirectUrl with actual values from match
+  for (const [key, value] of Object.entries(match.groups ?? {})) {
+    constructedUrl = constructedUrl.replace(`:${key}`, value);
+  }
+
+  return constructedUrl;
+}


### PR DESCRIPTION
# Context

We have a Redirects document type in the CMS for managing dynamic redirects. We need the web app to performantly retrieve these redirects before every route call, check them for a matching redirect, and redirect the user if necessary. This can all be managed in the CMS without developer input

Note that for a large number of pre-known redirects, like in a site migration, a code oriented approach, with a bloom filter for static redirects, is a better approach, and will be supported in Lucidity at a later date.

# Overview

This PR implements that redirect retrieval and processing within the Next.js app. It uses a Middleware to initially hook into the request and look for a matching redirect. It calls a serverless function to actually retrieve the redirects, so that we can cache that redirect lookup. This is because we Vercel does not support caching in Middleware.

The redirects entry point in the web application can be found in `apps/web/src/middleware/cmsRedirects.ts`

## Configuration

To keep the application as optimised as possible, you should explicitly skip all paths where redirects shouldn't be processed. Currently this is set for any path starting with `/api`, and all files with the following path extensions:

```
  'index.xml',
  'sitemap.xml',
  'style.xsl',
  '.css',
  '.png',
  '.svg',
  '.jpg',
  '.webp',
  '.aiff',
  '.woff',
  '.woff2',
  '.mp3',
  '.mp4',
```

This is all managed inside `apps/web/config/redirects.ts`.

> Note that the paths that middleware are skipped for (`'/((?!_next/static|_next/image|robots.txt|humans.txt|favicon.ico|apple-touch-icon*|.*\\.svg$|.*\\.png$|.*\\.css$|assets/.*).*)',`) also apply, so redirects will not be processed for these. These are managed for all middleware in `apps/web/app/src/middleware.ts`

## Supporting Packages

### Sanity Toolkit Redirects feature

The Sanity Toolkit at packages/sanity-toolkit has a redirects feature for managing common redirects functionality. This manages common constants, types, utilities and schema types for redirects in Sanity.

The system consists of a Sanity schema for defining redirects with support for both internal (CMS page) and external URL targets, along with pattern-matching capabilities for source paths.

Redirects can be configured as permanent (308) or temporary (307), and support dynamic path parameters with regex pattern matching.