### PR TITLE
feat: add modular content blocks nesting UI

### DIFF
--- a/apps/sanity/features/modular-content-blocks/blocks/outer/Section/schema.ts
+++ b/apps/sanity/features/modular-content-blocks/blocks/outer/Section/schema.ts
@@ -7,13 +7,13 @@ import { requiredIfParentIs } from '@pkg/sanity-toolkit/studio/schema/validation
 import { defineAnchorIdField } from '@pkg/sanity-toolkit/studio/schema/fields/defineAnchorIdField';
 import { defineImageField } from '@pkg/sanity-toolkit/studio/schema/fields/defineImageField';
 import { BLOCK_FIELDSETS } from '@pkg/modular-content-blocks/constants';
-import { defineOuterBlock } from '@pkg/modular-content-blocks/sanity/schema/defineModularBlockField';
 import {
   SECTION_MEDIA_SIZE,
   SECTION_ALIGNMENT_OPTION,
   SECTION_IMAGE_PLACEMENT,
   SECTION_MEDIA_TYPE,
 } from '@pkg/common/constants/blocks/outer/section';
+import { defineOuterBlock } from '@/features/modular-content-blocks/schema/defineOuterBlockField';
 
 interface Prepare {
   image?: Image;
@@ -156,7 +156,7 @@ export const schema = defineOuterBlock({
       image: 'image',
       variant: 'variant',
     },
-    prepare() {
+    prepare(_prepare: Prepare) {
       return {
         title: 'Section',
         media: blockIcon,

--- a/apps/sanity/features/modular-content-blocks/schema/defineOuterBlockField.ts
+++ b/apps/sanity/features/modular-content-blocks/schema/defineOuterBlockField.ts
@@ -1,0 +1,8 @@
+import { defineOuterBlockFn } from '@pkg/modular-content-blocks/sanity/schema/defineModularBlockField';
+import type { FieldToChildFieldsMap } from '@pkg/modular-content-blocks/sanity/types';
+
+const fieldToChildFields: FieldToChildFieldsMap = {
+  default: ['content'],
+};
+
+export const defineOuterBlock = defineOuterBlockFn(fieldToChildFields);

--- a/apps/sanity/sanity.config.ts
+++ b/apps/sanity/sanity.config.ts
@@ -3,13 +3,14 @@ import { structureTool } from 'sanity/structure';
 import { visionTool } from '@sanity/vision';
 import { schemaTypes } from './schema/types';
 import { codeInput } from '@sanity/code-input';
-import { structure } from '@/structure';
 import { defaultDocumentNode } from '@/structure/defaultDocumentNode';
-import { appConfig } from './config/app';
 import { setupSingletons } from '@pkg/sanity-toolkit/studio/singletons';
 import { LOCKED_DOCUMENT_TYPES } from '@pkg/common/config/schemaTypes';
 import { noteField } from '@pkg/sanity-toolkit/studio/studioComponents/noteField/plugin';
+import { PreventClickAwayItemComponent } from '@pkg/modular-content-blocks/sanity/components/PreventClickAwayItemComponent';
+import { structure } from '@/structure';
 import { documentActions } from '@/actions';
+import { appConfig } from './config/app';
 
 export default defineConfig({
   name: 'default',
@@ -21,9 +22,7 @@ export default defineConfig({
   plugins: [
     noteField(),
     codeInput(),
-    // Set up UI and logic for managing and editing Singleton documents
     setupSingletons(LOCKED_DOCUMENT_TYPES),
-    // Add the Structure Tool
     structureTool({
       name: 'content',
       title: 'Content',
@@ -35,6 +34,12 @@ export default defineConfig({
 
   document: {
     actions: documentActions,
+  },
+
+  form: {
+    components: {
+      item: PreventClickAwayItemComponent,
+    },
   },
 
   schema: {

--- a/packages/modular-content-blocks/sanity/components/OuterBlockItemComponent.tsx
+++ b/packages/modular-content-blocks/sanity/components/OuterBlockItemComponent.tsx
@@ -86,9 +86,9 @@ export function makeOuterBlockItemComponentFn(
           {
             ...contentMember,
             field: {
-              ...(contentMember.field || {}),
+              ...contentMember.field,
               schemaType: {
-                ...(contentMember.field?.schemaType || {}),
+                ...contentMember.field?.schemaType,
                 title: ' ', // Empty string to hide original field title
               },
             },

--- a/packages/modular-content-blocks/sanity/components/OuterBlockItemComponent.tsx
+++ b/packages/modular-content-blocks/sanity/components/OuterBlockItemComponent.tsx
@@ -1,0 +1,119 @@
+import type { ObjectItemProps, ObjectMember } from 'sanity';
+import { Card, Stack } from '@sanity/ui';
+import type { ComponentType } from 'react';
+import { ModularBlocksProvider } from '../context/ModularBlocksProvider';
+import type {
+  ContentMember,
+  FieldToChildFieldsMap,
+  OuterBlockPreviewResult,
+  SanityObjectItemPropsChildren,
+} from '../types';
+
+/**
+ * Default to showing the `content` field in the second layer for each block if it's defined.
+ */
+const defaultFieldToChildFields: FieldToChildFieldsMap = {
+  default: ['content'],
+};
+
+export function makeOuterBlockItemComponentFn(
+  fieldToChildFields: FieldToChildFieldsMap = defaultFieldToChildFields,
+) {
+  const OuterBlockItemComponent: ComponentType<ObjectItemProps> = (props) => {
+    if (
+      !props.children ||
+      typeof props.children !== 'object' ||
+      !('props' in props.children)
+    ) {
+      return props.renderDefault(props);
+    }
+
+    const {
+      type,
+      children,
+      hasInnerBlocks = false,
+    } = getChildrenPreview(props, props.children as SanityObjectItemPropsChildren);
+
+    return (
+      <Stack>
+        <Card>
+          <Card margin={2} style={{ marginBottom: type === 'preview' ? '-10px' : '0' }}>
+            <ModularBlocksProvider>{props.renderDefault(props)}</ModularBlocksProvider>
+          </Card>
+          {
+            <Card
+              paddingX={6}
+              paddingBottom={hasInnerBlocks ? 5 : 4}
+              borderBottom={hasInnerBlocks}
+            >
+              <ModularBlocksProvider overviewPreview={true}>{children}</ModularBlocksProvider>
+            </Card>
+          }
+        </Card>
+      </Stack>
+    );
+  };
+
+  return OuterBlockItemComponent;
+
+  function getChildrenPreview(
+    props: ObjectItemProps,
+    children: SanityObjectItemPropsChildren,
+  ): OuterBlockPreviewResult {
+    const type = props.value._type ?? 'default';
+
+    const childFields =
+      type in fieldToChildFields ? fieldToChildFields[type] : fieldToChildFields.default;
+
+    const childrenProps = children.props;
+
+    if (typeof childFields === 'function') {
+      return {
+        type: 'custom',
+        children: childFields(childrenProps),
+        hasInnerBlocks: false,
+      };
+    }
+
+    const members = childrenProps.children?.props?.members;
+    const contentMember = members?.find(
+      (member: ObjectMember) => 'name' in member && childFields?.includes(member.name),
+    ) as ContentMember | undefined;
+
+    const modifiedMembers = !contentMember
+      ? []
+      : [
+          {
+            ...contentMember,
+            field: {
+              ...(contentMember.field || {}),
+              schemaType: {
+                ...(contentMember.field?.schemaType || {}),
+                title: ' ', // Empty string to hide original field title
+              },
+            },
+          },
+        ];
+
+    // Deep clone object so the regular modal view is unaffected
+    // while showing only the "inner" modular content, and removing its "title" via empty string
+    return {
+      type: 'preview',
+      childFields,
+      hasInnerBlocks: !!contentMember,
+      children: {
+        ...children,
+        props: {
+          ...childrenProps,
+          children: {
+            ...((childrenProps.children ?? {}) as Record<string, any>),
+            props: {
+              ...((childrenProps.children?.props ?? {}) as Record<string, any>),
+              members: modifiedMembers,
+            },
+          },
+        },
+      },
+    };
+  }
+}

--- a/packages/modular-content-blocks/sanity/components/PreventClickAwayItemComponent.tsx
+++ b/packages/modular-content-blocks/sanity/components/PreventClickAwayItemComponent.tsx
@@ -1,0 +1,20 @@
+import type { ItemProps } from 'sanity';
+import { useModularBlocks } from '../context/ModularBlocksProvider';
+
+export function PreventClickAwayItemComponent(props: ItemProps) {
+  const { state } = useModularBlocks();
+
+  if (!('onClose' in props)) {
+    return props.renderDefault(props);
+  }
+
+  return props.renderDefault({
+    ...props,
+    onClose: (...args) => {
+      if (!state.overviewPreview) {
+        // This isn't an overviewPreview, so it's the real onClose handler. So close it!
+        props.onClose(...args);
+      }
+    },
+  });
+}

--- a/packages/modular-content-blocks/sanity/context/ModularBlocksProvider.tsx
+++ b/packages/modular-content-blocks/sanity/context/ModularBlocksProvider.tsx
@@ -1,0 +1,36 @@
+import { useContext, createContext, type ReactNode } from 'react';
+
+export const ModularBlocksContext = createContext({
+  state: {
+    /**
+     * Outer Modular Content Blocks show their inner blocks in an "overview preview" when viewing a Document.
+     * However, this overview preview was also registering event handlers to handle closing the modals
+     * on "click outside". This made it impossible to edit the inner fields content, without the modal closing.
+     *
+     * The `overviewPreview` state is used to wrap these overview preview components, storing whether the child
+     * components are being rendered in an overview preview. The inner block custom components then check this context
+     * and override the `onClose()` event handler if they are in an overview preview context, thus eliminating the issue.
+     */
+    overviewPreview: false,
+  },
+});
+
+export const ModularBlocksProvider = ({
+  children,
+  overviewPreview,
+}: {
+  children: ReactNode;
+  overviewPreview?: boolean;
+}) => {
+  const value = {
+    state: { overviewPreview: overviewPreview ?? false },
+  };
+
+  return (
+    <ModularBlocksContext.Provider value={value}>{children}</ModularBlocksContext.Provider>
+  );
+};
+
+export const useModularBlocks = () => {
+  return useContext(ModularBlocksContext);
+};

--- a/packages/modular-content-blocks/sanity/schema/defineModularBlockField.ts
+++ b/packages/modular-content-blocks/sanity/schema/defineModularBlockField.ts
@@ -1,21 +1,28 @@
 // import { BlockSchemaDefinition } from '../../components/BlockWizard/types/blockSchema';
-// import { OuterBlockItemComponent } from '../../components/OuterBlockItemComponent';
+import { makeOuterBlockItemComponentFn } from '../components/OuterBlockItemComponent';
 // import { InnerBlockItemComponent } from '../../components/InnerBlockItemComponent';
 import { innerBlockFieldsets, outerBlockFieldsets } from './blockFieldsets';
 import type { BlockSchemaDefinition } from '../../types/BlockSchemaDefinition';
+import type { FieldToChildFieldsMap } from '../types';
 
-// @todo Add the components for the Item Components
+/**
+ * Define the
+ * @param fieldToChildFields
+ */
+export function defineOuterBlockFn(fieldToChildFields?: FieldToChildFieldsMap) {
+  const outerBlockItemComponent = makeOuterBlockItemComponentFn(fieldToChildFields);
 
-export function defineOuterBlock(schemaTypeDefinition: BlockSchemaDefinition) {
-  return {
-    ...schemaTypeDefinition,
-    type: 'object',
-    fieldsets: [...outerBlockFieldsets(), ...(schemaTypeDefinition.fieldsets ?? [])],
-    components: {
-      ...(schemaTypeDefinition.components ?? {}),
-      // item: schemaTypeDefinition.components?.item ?? OuterBlockItemComponent,
-    },
-  } satisfies BlockSchemaDefinition;
+  return function defineOuterBlock(schemaTypeDefinition: BlockSchemaDefinition) {
+    return {
+      ...schemaTypeDefinition,
+      type: 'object',
+      fieldsets: [...outerBlockFieldsets(), ...(schemaTypeDefinition.fieldsets ?? [])],
+      components: {
+        ...(schemaTypeDefinition.components ?? {}),
+        item: schemaTypeDefinition.components?.item ?? makeOuterBlockItemComponentFn(),
+      },
+    } satisfies BlockSchemaDefinition;
+  };
 }
 
 export function defineInnerBlock(schemaTypeDefinition: BlockSchemaDefinition) {

--- a/packages/modular-content-blocks/sanity/schema/defineModularBlockField.ts
+++ b/packages/modular-content-blocks/sanity/schema/defineModularBlockField.ts
@@ -18,7 +18,7 @@ export function defineOuterBlockFn(fieldToChildFields?: FieldToChildFieldsMap) {
       type: 'object',
       fieldsets: [...outerBlockFieldsets(), ...(schemaTypeDefinition.fieldsets ?? [])],
       components: {
-        ...(schemaTypeDefinition.components ?? {}),
+        ...schemaTypeDefinition.components,
         item: schemaTypeDefinition.components?.item ?? makeOuterBlockItemComponentFn(),
       },
     } satisfies BlockSchemaDefinition;
@@ -31,7 +31,7 @@ export function defineInnerBlock(schemaTypeDefinition: BlockSchemaDefinition) {
     type: 'object',
     fieldsets: [...innerBlockFieldsets(), ...(schemaTypeDefinition.fieldsets ?? [])],
     components: {
-      ...(schemaTypeDefinition.components ?? {}),
+      ...schemaTypeDefinition.components,
       // item: schemaTypeDefinition.components?.item ?? InnerBlockItemComponent,
     },
   } satisfies BlockSchemaDefinition;

--- a/packages/modular-content-blocks/sanity/types/index.ts
+++ b/packages/modular-content-blocks/sanity/types/index.ts
@@ -1,0 +1,36 @@
+import type { ObjectItemProps, ObjectMember } from 'sanity';
+import type { ReactNode } from 'react';
+
+export type FieldToChildFieldsMap = Record<
+  string,
+  Array<string> | ((props: ObjectItemProps) => ReactNode)
+>;
+
+// Define a more specific type for the children props structure
+export interface SanityObjectItemPropsChildren {
+  props: ObjectItemProps & {
+    children?: {
+      props?: {
+        members?: ObjectMember[];
+      };
+    };
+  };
+}
+
+// Define a type for content members with field property
+export type ContentMember = ObjectMember & {
+  field?: {
+    schemaType: {
+      title: string;
+      [key: string]: any;
+    };
+    [key: string]: any;
+  };
+};
+
+export interface OuterBlockPreviewResult {
+  type: 'preview' | 'custom';
+  children: any; // Use any here to avoid ReactNode compatibility issues
+  hasInnerBlocks: boolean;
+  childFields?: Array<string>;
+}


### PR DESCRIPTION
# Overview

This PR implements improved nesting view of modular content, when using blocks within blocks.

It can be implemented for any of our page builder approaches outlined in #127.

It maintains all functionality available to nested content blocks, but exposes it at the root level so it's easier to interact with.

## Caveats

Currently there are click away handlers added by Sanity. These get duplicated by this implementation. To counteract this, all studio `item` components are replaced by a `PreventClickAwayItemComponent`. This just checks if the item is within the new area, and hijacks the click away handler to do nothing.

If you're changing the `item` component on fields, you'll need to add the same Context check to prevent click away yourself. You'll know if it's broken when trying to click on a field to edit it closes the modal dialog.

I'm working with Sanity to try and remove this requirement entirely, but this is the current workaround.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/e7bf702f-05d5-4697-9880-6225297c3326)

After:
![image](https://github.com/user-attachments/assets/94869a5f-5c75-4669-967e-db6e5f470c32)
