### PR TITLE
fix: fix slug generation when slug has a folder

### DIFF
--- a/packages/sanity-toolkit/studio/studioComponents/superFields/slug/components/PathInput/PathInput.tsx
+++ b/packages/sanity-toolkit/studio/studioComponents/superFields/slug/components/PathInput/PathInput.tsx
@@ -2,11 +2,12 @@
 // Customised specifically at time of this commit: https://github.com/sanity-io/sanity/blob/d157fca17d146886413f86577258fb24ee35e3d2/packages/sanity/src/core/form/inputs/Slug/SlugInput.tsx
 
 import { Box, Flex, TextInput } from '@sanity/ui';
+import type { FormEventHandler, MouseEventHandler, ReactElement } from 'react';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import type { MouseEventHandler, FormEventHandler, ReactElement } from 'react';
 import type { SuperSlugInputProps } from '../../types';
 import { FolderInput } from '../FolderInput';
 import type { UpdateSlugFn } from '../../hooks/useSuperSlugField';
+import { joinSlugSegments } from '../../utilities';
 
 const folderOptionDefaults = { canUnlock: true };
 
@@ -90,9 +91,6 @@ export function PathInput(
   );
 }
 
-function joinSlugSegments(segments: Array<string | undefined>) {
-  return segments.filter((part) => typeof part === 'string').join('/');
-}
 function removeTrailingSlash(string: string | undefined): string | undefined {
   if (!string) {
     return string;

--- a/packages/sanity-toolkit/studio/studioComponents/superFields/slug/components/SuperSlugInput.tsx
+++ b/packages/sanity-toolkit/studio/studioComponents/superFields/slug/components/SuperSlugInput.tsx
@@ -28,6 +28,7 @@ export function makeSuperSlugInput({ apiVersion }: { apiVersion: string }) {
       sourceField,
       schemaType,
       path,
+      folderSlug: superSlugField.folderSlug,
       updateSlug: superSlugField.updateSlug,
     });
 

--- a/packages/sanity-toolkit/studio/studioComponents/superFields/slug/hooks/useSlugGenerator.ts
+++ b/packages/sanity-toolkit/studio/studioComponents/superFields/slug/hooks/useSlugGenerator.ts
@@ -3,7 +3,7 @@ import { useGetFormValue, useTranslation } from 'sanity';
 import type { Path, SanityDocument } from 'sanity';
 import type { SlugSourceFn, SuperSlugInputProps } from '../types';
 import { useSlugContext } from './useSlugContext';
-import { getNewFromSource, getSlugSourceContext } from '../utilities';
+import { getNewFromSource, getSlugSourceContext, joinSlugSegments } from '../utilities';
 import type { UpdateSlugFn } from './useSuperSlugField';
 import { useAsync } from '../../../../../hooks/useAsync';
 
@@ -16,6 +16,8 @@ interface Props {
   schemaType: SuperSlugInputProps['schemaType'];
   /** The path to the slug field. */
   path: Path;
+  /** The folder path, if defined */
+  folderSlug?: string;
   /** The callback to update the slug value. */
   updateSlug: UpdateSlugFn;
 }
@@ -33,6 +35,7 @@ export function useSlugGenerator({
   sourceField,
   schemaType,
   path,
+  folderSlug,
   updateSlug,
 }: Props) {
   const getFormValue = useGetFormValue();
@@ -54,8 +57,17 @@ export function useSlugGenerator({
 
     const newFromSource = await getNewFromSource(sourceField, document, sourceContext);
 
-    void updateSlug(newFromSource);
-  }, [sourceField, getFormValue, schemaType, path, slugContext, updateSlug, t]);
+    void updateSlug(joinSlugSegments([folderSlug, newFromSource]));
+  }, [
+    sourceField,
+    getFormValue,
+    schemaType.name,
+    path,
+    slugContext,
+    updateSlug,
+    folderSlug,
+    t,
+  ]);
 
   const [generateSlugState, handleGenerateSlug] = useAsync(handleAsyncGenerateSlug);
 

--- a/packages/sanity-toolkit/studio/studioComponents/superFields/slug/utilities/index.ts
+++ b/packages/sanity-toolkit/studio/studioComponents/superFields/slug/utilities/index.ts
@@ -79,3 +79,7 @@ export async function getNewFromSource(
     ? source(document, context)
     : PathUtils.get(document, source);
 }
+
+export function joinSlugSegments(segments: Array<string | undefined>) {
+  return segments.filter((part) => typeof part === 'string').join('/');
+}


### PR DESCRIPTION
Slug generation was overwriting the current folder.

This commit fixes that, ensuring folders are not overridden unless unlocked
